### PR TITLE
Refactor HDF5 module and object information

### DIFF
--- a/mccode_antlr/io/hdf5.py
+++ b/mccode_antlr/io/hdf5.py
@@ -2,14 +2,6 @@ from pathlib import Path
 from typing import Union
 from zenlog import log
 
-from mccode_antlr.instr import Instance
-from mccode_antlr.comp import Comp
-from mccode_antlr.common import InstrumentParameter, MetaData, ComponentParameter, RawC
-from mccode_antlr.instr.jump import Jump
-from mccode_antlr.common.expression import Expr, TrinaryOp, BinaryOp, UnaryOp
-from mccode_antlr.instr.orientation import (Matrix, Vector, Angles, Rotation, Seitz, RotationX, RotationY,
-                                            RotationZ, TranslationPart, Orient, Parts, Part)
-
 VERSION_NAME_KEY = 'mccode-antlr_version_data-type-name'
 
 
@@ -173,7 +165,7 @@ class InstrIO:
 
 
 class GroupIO:
-    from mccode_antlr.instr.group import Group
+    from mccode_antlr.instr import Instance, Group
 
     @staticmethod
     def load(group, instances: dict[str, Instance], **kwargs) -> Group:
@@ -398,6 +390,13 @@ def _direct_io(cls, convert=None):
 
 
 class HDF5IO:
+    from mccode_antlr.comp import Comp
+    from mccode_antlr.common import InstrumentParameter, MetaData, ComponentParameter, RawC
+    from mccode_antlr.common.expression import Expr, TrinaryOp, BinaryOp, UnaryOp
+    from mccode_antlr.instr.jump import Jump
+    from mccode_antlr.instr.orientation import (Matrix, Vector, Angles, Rotation, Seitz, RotationX, RotationY,
+                                                RotationZ, TranslationPart, Orient, Parts, Part)
+
     _handlers = {
         'Instr': InstrIO,
         'InstrumentParameter': _dataclass_io(InstrumentParameter, attrs=('name', 'unit'), required=('value',)),

--- a/mccode_antlr/io/hdf5.py
+++ b/mccode_antlr/io/hdf5.py
@@ -10,22 +10,63 @@ from mccode_antlr.instr.orientation import Orient, Parts, Part
 from mccode_antlr.common.expression import Expr, TrinaryOp, BinaryOp, UnaryOp
 
 
-def _write_header(group, what):
+def _write_info_group(hdf_obj, data_type):
     from mccode_antlr import __version__
-    group.attrs['mccode_antlr_version'] = __version__
-    group.attrs['mccode_antlr_type'] = what
-
-
-def _check_header(group, what):
-    from mccode_antlr import __version__
-    if 'mccode_antlr_version' not in group.attrs:
-        raise RuntimeError(f"File does not have mccode_antlr version information")
-    if group.attrs['mccode_antlr_version'] != __version__:
-        raise RuntimeError(f"File was created with mccode_antlr version {group.attrs['mccode_antlr_version']}, "
+    if '/mccode_antlr' not in hdf_obj:
+        hdf_obj.create_group('/mccode_antlr')
+    group = hdf_obj['/mccode_antlr']
+    if 'version' not in group.attrs:
+        group.attrs['version'] = __version__
+    if group.attrs['version'] != __version__:
+        raise RuntimeError(f"File was created with mccode_antlr version {group.attrs['version']}, "
                            f"but this is version {__version__}")
-    if group.attrs['mccode_antlr_type'] != what:
-        raise RuntimeError(f"File was created with mccode_antlr type {group.attrs['mccode_antlr_type']}, "
-                           f"but asked to read type {what}")
+    if 'types' not in group:
+        import h5py
+        dt = h5py.string_dtype(encoding='utf-8')
+        types = HDF5IO.registered()
+        group.create_dataset('types', (len(types),), dtype=dt, maxshape=(len(types),))
+        for idx, name in enumerate(types):
+            group['types'][idx] = name
+    data_type_name_bytes = data_type.__name__.encode('utf-8')
+    if data_type_name_bytes not in group['types']:
+        raise ValueError(f"Data type {data_type} not registered")
+    type_index = list(group['types']).index(data_type_name_bytes)
+
+    # if data_type.__name__ not in group:
+    #     group.create_group(data_type.__name__)
+    # dt_group = group[data_type.__name__]
+    # # TODO: Add a representation of the data type to the group?
+    # return group.ref, dt_group.ref
+    return group.ref, type_index
+
+
+def _write_header(group, data_type):
+    ref, index = _write_info_group(group.file, data_type)
+    group.attrs['info_ref'] = ref
+    group.attrs['type_index'] = index
+
+
+def _check_header(group, data_type):
+    from mccode_antlr import __version__
+    if 'info_ref' not in group.attrs:
+        raise RuntimeError(f"Group does not have information group reference")
+    if 'type_index' not in group.attrs:
+        raise RuntimeError(f"Group does not have type index")
+    info = group.file[group.attrs['info_ref']]
+    index = group.attrs['type_index']
+    name = info.name[1:]
+    if name != 'mccode_antlr':
+        raise RuntimeError(f"File is not a mccode_antlr file")
+    if 'version' not in info.attrs:
+        raise RuntimeError(f"File does not have {name} version information")
+    if info.attrs['version'] != __version__:
+        raise RuntimeError(f"File was created with {name} version {info.attrs['version']}, "
+                           f"but this is mccode_antlr version {__version__}")
+
+    data_type_name = data_type.__name__.encode('utf-8')
+    if info['types'][index] != data_type_name:
+        raise RuntimeError(f"File was created with {name} type {info['types'][index]}, "
+                           f"but asked to read type {data_type}")
 
 
 def _standard_read(typename, group, attrs, optional, required, **kwargs):
@@ -41,7 +82,7 @@ def _standard_read(typename, group, attrs, optional, required, **kwargs):
             log.warn('Missing required value!')
             values[name] = None
     if any(values[r] is None for r in required):
-        raise ValueError(f"Could not load required values for {group.attrs['mccode_antlr_type']}")
+        raise ValueError(f"Could not load required values for {typename}")
     return values
 
 
@@ -56,16 +97,14 @@ def _standard_save(typename, group, data, attrs, fields, **kwargs):
 
 
 def _dataclass_io(real_type, attrs, optional, required=()):
-    typename = real_type.__name__
-
     class _DataclassIO:
         @staticmethod
         def load(group, **kwargs) -> real_type:
-            return real_type(**_standard_read(typename, group, attrs, optional, required, **kwargs))
+            return real_type(**_standard_read(real_type, group, attrs, optional, required, **kwargs))
 
         @staticmethod
         def save(group, data, **kwargs):
-            _standard_save(typename, group, data, attrs, optional+required, **kwargs)
+            _standard_save(real_type, group, data, attrs, optional+required, **kwargs)
 
     return _DataclassIO
 
@@ -88,12 +127,12 @@ class DataSourceIO:
 
     @staticmethod
     def load(group, **kwargs) -> DataSource:
-        values = _standard_read('DataSource', group, ('name', 'type_name'), (), (), **kwargs)
+        values = _standard_read(DataSourceIO.DataSource, group, ('name', 'type_name'), (), (), **kwargs)
         return DataSourceIO.DataSource.from_type_name_and_name(values['type_name'], values['name'])
 
     @staticmethod
     def save(group, data, **kwargs):
-        _standard_save('DataSource', group, data, ('name', 'type_name'), (), **kwargs)
+        _standard_save(DataSourceIO.DataSource, group, data, ('name', 'type_name'), (), **kwargs)
 
 
 class InstanceIO:
@@ -104,7 +143,7 @@ class InstanceIO:
 
     @staticmethod
     def load(group, instances: dict[str, Instance], components: dict[str, Comp], **kwargs) -> Instance:
-        values = _standard_read('Instance', group, InstanceIO.attrs, InstanceIO.names, required=(), **kwargs)
+        values = _standard_read(InstanceIO.Instance, group, InstanceIO.attrs, InstanceIO.names, required=(), **kwargs)
         # handle the special cases: type, at_relative, rotate_relative
         # type:
         type_name = group.attrs.get('type')
@@ -127,7 +166,7 @@ class InstanceIO:
 
     @staticmethod
     def save(group, data: Instance, **kwargs):
-        _standard_save('Instance', group, data, InstanceIO.attrs, InstanceIO.names, **kwargs)
+        _standard_save(InstanceIO.Instance, group, data, InstanceIO.attrs, InstanceIO.names, **kwargs)
         # type, at_relative, rotate_relative should be _references_ to other HDF5 objects?
         # Maybe we can get away with only keeping their names, since those are unique in the instrument
         # component _type_ name:
@@ -150,13 +189,13 @@ class InstrIO:
 
     @staticmethod
     def load(group, **kwargs) -> Instr:
-        values = _standard_read('Instr', group, InstrIO.attrs, InstrIO.names, required=(), **kwargs)
+        values = _standard_read(InstrIO.Instr, group, InstrIO.attrs, InstrIO.names, required=(), **kwargs)
         # We had to write the component type definitions, so that they could be loaded before the instances:
         component_types = {component.name: component for component in HDF5IO.load(group['components'])}
         # And the instances need to know which component types and instances have already been loaded:
         known_instances = {}
         # Maybe we could modify the tuple loader to avoid this complexity, but this works for now
-        _check_header(group['instances'], 'tuple')
+        _check_header(group['instances'], tuple)
         instance_count = group['instances'].attrs['length']
         pad = len(str(instance_count))
         instances = []
@@ -171,7 +210,7 @@ class InstrIO:
 
     @staticmethod
     def save(group, data: Instr, **kwargs):
-        _standard_save('Instr', group, data, InstrIO.attrs, InstrIO.names, **kwargs)
+        _standard_save(InstrIO.Instr, group, data, InstrIO.attrs, InstrIO.names, **kwargs)
         # The groups field does not need special treatment for saving, but does for loading
         HDF5IO.save(group=group.create_group('groups'), data=data.groups)
         # the instances _must_ be recorded in order (we can recover their names later):
@@ -185,14 +224,14 @@ class GroupIO:
 
     @staticmethod
     def load(group, instances: dict[str, Instance], **kwargs) -> Group:
-        values = _standard_read('Group', group, ('name', 'index'), (), ('ids', 'member_names'), **kwargs)
+        values = _standard_read(GroupIO.Group, group, ('name', 'index'), (), ('ids', 'member_names'), **kwargs)
         values['members'] = [instances[name] for name in values['member_names']]
         del values['member_names']
         return GroupIO.Group(**values)
 
     @staticmethod
     def save(group, data, **kwargs):
-        _standard_save('Group', group, data, ('name', 'index'), ('ids', ), **kwargs)
+        _standard_save(GroupIO.Group, group, data, ('name', 'index'), ('ids', ), **kwargs)
         HDF5IO.save(group=group.create_group('member_names'), data=[member.name for member in data.members])
 
 
@@ -201,7 +240,7 @@ class RemoteRegistryIO:
 
     @staticmethod
     def load(group, **kwargs) -> Registry:
-        values = _standard_read('RemoteRegistry', group, ('name', 'filename', 'url'), (), (), **kwargs)
+        values = _standard_read(RemoteRegistryIO.RemoteRegistry, group, ('name', 'filename', 'url'), (), (), **kwargs)
         try:
             return RemoteRegistryIO.RemoteRegistry(**values)
         except RuntimeError:
@@ -210,7 +249,7 @@ class RemoteRegistryIO:
 
     @staticmethod
     def save(group, data, **kwargs):
-        _standard_save('RemoteRegistry', group, data, ('name', 'filename'), (), **kwargs)
+        _standard_save(RemoteRegistryIO.RemoteRegistry, group, data, ('name', 'filename'), (), **kwargs)
         if data.pooch.base_url is not None:
             group.attrs['url'] = data.pooch.base_url
 
@@ -220,7 +259,7 @@ class LocalRegistryIO:
 
     @staticmethod
     def load(group, **kwargs) -> Registry:
-        values = _standard_read('LocalRegistry', group, ('name', 'root'), (), (), **kwargs)
+        values = _standard_read(LocalRegistryIO.LocalRegistry, group, ('name', 'root'), (), (), **kwargs)
         try:
             return LocalRegistryIO.LocalRegistry(**values)
         except RuntimeError:
@@ -229,31 +268,31 @@ class LocalRegistryIO:
 
     @staticmethod
     def save(group, data, **kwargs):
-        _standard_save('LocalRegistry', group, data, ('name',), (), **kwargs)
+        _standard_save(LocalRegistryIO.LocalRegistry, group, data, ('name',), (), **kwargs)
         if data.root is not None:
             group.attrs['root'] = data.root.as_posix()
 
 
-def _seitz_part_io(actual_type, typename):
+def _seitz_part_io(actual_type):
     class _RotationPartIO:
         @staticmethod
         def load(group, **kwargs):
-            _check_header(group, typename)
+            _check_header(group, actual_type)
             v = HDF5IO.load(group['v'], **kwargs)
             if v is None:
-                raise ValueError(f"Could not load v for {typename}")
+                raise ValueError(f"Could not load v for {actual_type}")
             return actual_type(v=v)
 
         @staticmethod
         def save(group, data, **kwargs):
-            _write_header(group, typename)
+            _write_header(group, actual_type)
             if data.v is not None:
                 HDF5IO.save(group=group.create_group('v'), data=data.v, **kwargs)
 
     return _RotationPartIO
 
 
-def _named_tuple_io(actual_type, typename, names):
+def _named_tuple_io(typename, names):
     class _NamedTupleIO:
         @staticmethod
         def load(group, **kwargs):
@@ -261,7 +300,7 @@ def _named_tuple_io(actual_type, typename, names):
             values = {name: HDF5IO.load(group[name], **kwargs) for name in names}
             if any(v is None for v in values.values()):
                 raise ValueError(f"Could not load values for {typename}")
-            return actual_type(**values)
+            return typename(**values)
 
         @staticmethod
         def save(group, data, **kwargs):
@@ -277,19 +316,17 @@ def _named_tuple_io(actual_type, typename, names):
 ExprIO = _dataclass_io(Expr, attrs=(), optional=('expr',))
 
 
-def _op_io(actual_type, fields: list[str]):
-    typename = actual_type.__name__
-
+def _op_io(typename, fields: list[str]):
     class _OpIO:
         @staticmethod
-        def load(group, **kwargs) -> actual_type:
+        def load(group, **kwargs) -> typename:
             from mccode_antlr.common.expression import DataType
             _check_header(group, typename)
             attrs = {name: group.attrs.get(name) for name in ('op', 'style', 'data_type_name')}
             values = {name: HDF5IO.load(group[name], **kwargs) for name in fields}
             if any(v is None for v in values.values()):
                 raise ValueError(f"Could not load values for {typename}")
-            op = actual_type(attrs['op'], **values)
+            op = typename(attrs['op'], **values)
             op.style = attrs['style']
             if op.data_type != DataType.from_name(attrs['data_type_name']):
                 raise ValueError(
@@ -297,7 +334,7 @@ def _op_io(actual_type, fields: list[str]):
             return op
 
         @staticmethod
-        def save(group, data: actual_type, **kwargs):
+        def save(group, data: typename, **kwargs):
             _write_header(group, typename)
             for name in ('op', 'style'):
                 if getattr(data, name) is not None:
@@ -321,7 +358,7 @@ class ValueIO:
     @staticmethod
     def load(group, **kwargs) -> Value:
         from mccode_antlr.common.expression import ObjectType, DataType, ShapeType
-        _check_header(group, 'Value')
+        _check_header(group, ValueIO.Value)
         types = {f: t.from_name(group.attrs.get(f'{f}_name'))
                  for t, f in ((ObjectType, 'object_type'), (DataType, 'data_type'), (ShapeType, 'shape_type'))}
         # A missing value is valid:
@@ -330,7 +367,7 @@ class ValueIO:
 
     @staticmethod
     def save(group, data: Value, **kwargs):
-        _write_header(group, 'Value')
+        _write_header(group, ValueIO.Value)
         for name in ('object_type', 'data_type', 'shape_type'):
             if getattr(data, name) is not None:
                 group.attrs[f'{name}_name'] = getattr(data, name).name
@@ -359,12 +396,12 @@ class ListIO:
 
     @staticmethod
     def load(group, **kwargs) -> list:
-        count, pad = _iterable_read_setup('list', group)
+        count, pad = _iterable_read_setup(list, group)
         return [HDF5IO.load(group=group[TupleIO.entry_name(idx, pad)], **kwargs) for idx in range(count)]
 
     @staticmethod
     def save(group, data: tuple, **kwargs):
-        pad = _iterable_save_setup('list', group, data)
+        pad = _iterable_save_setup(list, group, data)
         for idx, d in enumerate(data):
             HDF5IO.save(group=group.create_group(TupleIO.entry_name(idx, pad)), data=d, **kwargs)
 
@@ -376,12 +413,12 @@ class TupleIO:
 
     @staticmethod
     def load(group, **kwargs) -> tuple:
-        count, pad = _iterable_read_setup('tuple', group)
+        count, pad = _iterable_read_setup(tuple, group)
         return tuple(HDF5IO.load(group=group[TupleIO.entry_name(idx, pad)], **kwargs) for idx in range(count))
 
     @staticmethod
     def save(group, data: tuple, **kwargs):
-        pad = _iterable_save_setup('tuple', group, data)
+        pad = _iterable_save_setup(tuple, group, data)
         for idx, d in enumerate(data):
             HDF5IO.save(group=group.create_group(TupleIO.entry_name(idx, pad), **kwargs), data=d)
 
@@ -389,29 +426,28 @@ class TupleIO:
 class DictIO:
     @staticmethod
     def load(group, **kwargs) -> dict:
-        _check_header(group, 'dict')
+        _check_header(group, dict)
         return {k: HDF5IO.load(group=group[k], **kwargs) for k in group}
 
     @staticmethod
     def save(group, data: dict, **kwargs):
-        _write_header(group, 'dict')
+        _write_header(group, dict)
         for k, v in data.items():
             HDF5IO.save(group=group.create_group(k), data=v, **kwargs)
 
 
 def _direct_io(cls, convert=None):
-    type_name = cls.__name__
     convert = convert or cls
 
     class _DirectIO:
         @staticmethod
         def load(group):
-            _check_header(group, type_name)
+            _check_header(group, cls)
             return convert(group['entry'][()])
 
         @staticmethod
         def save(group, data):
-            _write_header(group, type_name)
+            _write_header(group, cls)
             group['entry'] = data
 
     return _DirectIO
@@ -436,16 +472,15 @@ class HDF5IO:
         'Orient': OrientIO,
         'Parts': PartsIO,
         'Part': PartIO,
-        'RotationX': _seitz_part_io(RotationX, 'RotationX'),
-        'RotationY': _seitz_part_io(RotationY, 'RotationY'),
-        'RotationZ': _seitz_part_io(RotationZ, 'RotationZ'),
-        'TranslationPart': _seitz_part_io(TranslationPart, 'TranslationPart'),
-        'Seitz': _named_tuple_io(Seitz, 'Seitz',
-                                 ('xx', 'xy', 'xz', 'xt', 'yx', 'yy', 'yz', 'yt', 'zx', 'zy', 'zz', 'zt')),
-        'Rotation': _named_tuple_io(Rotation, 'Rotation', ('xx', 'xy', 'xz', 'yx', 'yy', 'yz', 'zx', 'zy', 'zz')),
-        'Matrix': _named_tuple_io(Matrix, 'Matrix', ('xx', 'xy', 'xz', 'yx', 'yy', 'yz', 'zx', 'zy', 'zz')),
-        'Vector': _named_tuple_io(Vector, 'Vector', ('x', 'y', 'z')),
-        'Angles': _named_tuple_io(Angles, 'Angles', ('x', 'y', 'z')),
+        'RotationX': _seitz_part_io(RotationX),
+        'RotationY': _seitz_part_io(RotationY),
+        'RotationZ': _seitz_part_io(RotationZ),
+        'TranslationPart': _seitz_part_io(TranslationPart),
+        'Seitz': _named_tuple_io(Seitz, ('xx', 'xy', 'xz', 'xt', 'yx', 'yy', 'yz', 'yt', 'zx', 'zy', 'zz', 'zt')),
+        'Rotation': _named_tuple_io(Rotation,('xx', 'xy', 'xz', 'yx', 'yy', 'yz', 'zx', 'zy', 'zz')),
+        'Matrix': _named_tuple_io(Matrix, ('xx', 'xy', 'xz', 'yx', 'yy', 'yz', 'zx', 'zy', 'zz')),
+        'Vector': _named_tuple_io(Vector, ('x', 'y', 'z')),
+        'Angles': _named_tuple_io(Angles, ('x', 'y', 'z')),
         'Jump': JumpIO,
         'Expr': ExprIO,
         'Value': ValueIO,
@@ -460,6 +495,10 @@ class HDF5IO:
     }
 
     @classmethod
+    def registered(cls):
+        return cls._handlers.keys()
+
+    @classmethod
     def save(cls, group, data, **kwargs):
         name = data.__class__.__name__
         if name not in cls._handlers:
@@ -469,9 +508,12 @@ class HDF5IO:
 
     @classmethod
     def load(cls, group, **kwargs):
-        if 'mccode_antlr_type' not in group.attrs:
-            raise RuntimeError(f"File does not have mccode_antlr type information")
-        name = group.attrs['mccode_antlr_type']
+        if 'info_ref' not in group.attrs:
+            raise RuntimeError(f"Group does not have information group reference")
+        info = group.file[group.attrs['info_ref']]
+        if 'type_index' not in group.attrs:
+            raise RuntimeError(f"Group does not have type index")
+        name = info['types'][group.attrs['type_index']].decode('utf-8')
         if name not in cls._handlers:
             log.warn(f'No handler for {name}, skipping')
             return None

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -39,7 +39,6 @@ class HDFIOTestCase(unittest.TestCase):
         instr = parse_mcstas_instr(instr)
         filename = 'test.h5'
         save_hdf5(instr, self.td.joinpath(filename))
-        save_hdf5(instr, filename)
 
         read_instr = load_hdf5(self.td.joinpath(filename))
         self.assertEqual(instr.name, read_instr.name)

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -3,11 +3,13 @@ import unittest
 
 class HDFIOTestCase(unittest.TestCase):
     def setUp(self):
-        from tempfile import TemporaryFile
-        self.tf = TemporaryFile()
+        from pathlib import Path
+        from tempfile import mkdtemp
+        self.td = Path(mkdtemp())
 
     def tearDown(self):
-        self.tf.close()
+        from shutil import rmtree
+        rmtree(self.td)
 
     def test_one_axis(self):
         from mccode_antlr.io import load_hdf5, save_hdf5
@@ -35,10 +37,11 @@ class HDFIOTestCase(unittest.TestCase):
         END
         """
         instr = parse_mcstas_instr(instr)
-        save_hdf5(instr, self.tf)
-        save_hdf5(instr, 'test.h5')
+        filename = 'test.h5'
+        save_hdf5(instr, self.td.joinpath(filename))
+        save_hdf5(instr, filename)
 
-        read_instr = load_hdf5(self.tf)
+        read_instr = load_hdf5(self.td.joinpath(filename))
         self.assertEqual(instr.name, read_instr.name)
         instance_names = [c.name for c in instr.components]
         read_instance_names = [c.name for c in read_instr.components]


### PR DESCRIPTION
Storing any `mccode_antlr` object into an HDF5 file requires keeping track of the non-default properties of the object _plus_ minimal metadata about the object and the version of `mccode_antlr`.

At the moment the version is required to be equal at writing and reading time, to protect against internal object changes during this pre-`v1.0` era.
Eventually there could be a softening of this requirement, potentially with some built-in equivalency graph and/or automatic conversion.

The object metadata is only its name at present, e.g., `mccode_antlr.instr.Instr` must store `'Instr'` as an attribute of the HDF5 group that it is written into.

## Initial tried implementation
The first approach to record this metadata was to store both the module and object metadata as separate attributes for every group. This seemed wasteful, so an attempt was made to de-duplicate the metadata by storing the version once, and reduce the object name to an integer attribute with a file-global list of 'known' object names.

### Why the initial implementation was abandoned
Surprisingly, de-duplicating this information did not significantly reduce the test HDF5 size and at the same time significantly increase the test runtime.
This seems to be due to the global information having poor memory access time performance due to lack of data locality.

## Attempted improvements
The `HDF5IO` object was improved to cache the global metadata, with the idea that a faster lookup of the object name from its index in the 'known' list would be achieved. This did not produce the desired improvement in speed, possibly due to a poor cache implementation.

## Current implementation
Using an attribute for every group seems to be the best solution for speed of writing and reading a `mccode_antlr` object.
The metadata associated with every string-valued group attribute is surprisingly large, so the two pieces of information are now packed together into a single string attribute, e.g., `'{version}/{name}'` which produces demonstrably smaller  files.