### PR TITLE
[Add] pre-translation check if identifiers are instrument parameter names

### DIFF
--- a/mccode_antlr/common/expression.py
+++ b/mccode_antlr/common/expression.py
@@ -374,6 +374,11 @@ class TrinaryOp(Op):
     def __contains__(self, value):
         return value in self.first or value in self.second or value in self.third
 
+    def verify_parameters(self, instrument_parameter_names: list[str]):
+        for lr in (self.first, self.second, self.third):
+            for x in lr:
+                x.verify_parameters(instrument_parameter_names)
+
 
 class BinaryOp(Op):
     def __init__(self, op, left, right):
@@ -513,6 +518,11 @@ class BinaryOp(Op):
     def __contains__(self, value):
         return value in self.left or value in self.right
 
+    def verify_parameters(self, instrument_parameter_names: list[str]):
+        for lr in (self.left, self.right):
+            for x in lr:
+                x.verify_parameters(instrument_parameter_names)
+
 
 class UnaryOp(Op):
     def __init__(self, op, value):
@@ -608,6 +618,10 @@ class UnaryOp(Op):
 
     def __contains__(self, value):
         return value in self.value
+
+    def verify_parameters(self, instrument_parameter_names: list[str]):
+        for x in self.value:
+            x.verify_parameters(instrument_parameter_names)
 
 
 class Value:
@@ -986,6 +1000,11 @@ class Value:
             return self.value.strip('"') == value.strip('"')
         return self.value == value
 
+    def verify_parameters(self, instrument_parameter_names: list[str]):
+        if self.is_id and self.value in instrument_parameter_names:
+            self._object = ObjectType.parameter
+
+
 
 class Expr:
     def __init__(self, expr: Union[Value, UnaryOp, BinaryOp, list[Union[Value, UnaryOp, BinaryOp]]]):
@@ -1301,6 +1320,10 @@ class Expr:
 
     def copy(self):
         return Expr([x.copy() for x in self.expr])
+
+    def verify_parameters(self, instrument_parameter_names: list[str]):
+        for x in self.expr:
+            x.verify_parameters(instrument_parameter_names)
 
 
 def unary_expr(func, name, v):

--- a/mccode_antlr/instr/instance.py
+++ b/mccode_antlr/instr/instance.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from typing import TypeVar, Union
 from ..comp import Comp
 from ..common import Expr, Value, DataType
-from ..common import ComponentParameter, MetaData, parameter_name_present, RawC, blocks_to_raw_c
+from ..common import InstrumentParameter, ComponentParameter, MetaData, parameter_name_present, RawC, blocks_to_raw_c
 from .orientation import Orient, Vector, Angles
 from .jump import Jump
 
@@ -131,7 +131,18 @@ class Instance:
         # # is this parameter value *actually* an instrument parameter *name*
         # if value.is_id:
         #     pass
+        # # If a parameter is set to an instrument parameter name, we need to keep track of that here:
+        # TODO: Either add a reference to the containing instrument (and carry that around always)
+        #       Or perform this check when it comes time to translate the whole instrument :/
+
         self.parameters += (ComponentParameter(p.name, value), )
+
+    def verify_parameters(self, instrument_parameters: tuple[InstrumentParameter]):
+        """Check for instance parameters which are identifiers that match instrument parameter names,
+        and flag them as parameter objects"""
+        instrument_parameter_names = [x.name for x in instrument_parameters]
+        for par in self.parameters:
+            par.value.verify_parameters(instrument_parameter_names)
 
     def get_parameter(self, name: str):
         for par in self.parameters:

--- a/mccode_antlr/instr/instr.py
+++ b/mccode_antlr/instr/instr.py
@@ -464,6 +464,13 @@ class Instr:
                 log.warn(f'Removed unused instrument parameters; {len(self.parameters)} remain')
         return len(used) - sum(used)
 
+    def verify_instance_parameters(self):
+        """Check that all instance parameters are of the expected type, and that identifiers which match
+        instrument parameter names are flagged as such"""
+        for instance in self.components:
+            instance.verify_parameters(self.parameters)
+
+
 
 def _join_rawc_tuple(rawc_tuple: tuple[RawC]):
     return '\n'.join([str(rc) for rc in rawc_tuple])

--- a/mccode_antlr/translators/target.py
+++ b/mccode_antlr/translators/target.py
@@ -28,6 +28,7 @@ class TargetVisitor:
         self.component_declared_parameters = dict()
         self.ok_to_skip = None
         #
+        self.source.verify_instance_parameters()
         self.__post_init__()
 
     def __init_subclass__(cls, **kwargs):

--- a/test/test_instr.py
+++ b/test/test_instr.py
@@ -480,27 +480,6 @@ class CompiledInstr(CompiledTest):
         parameters = f'a1={a1} a2={2 * a1}'
         self._compile_and_run(instr, parameters)
 
-
-        # target = CBinaryTarget(mpi=False, acc=False, count=1, nexus=False)
-        # config = dict(default_main=True, enable_trace=False, portable=False, include_runtime=True,
-        #               embed_instrument_file=False, verbose=False)
-        # with TemporaryDirectory() as directory:
-        #     try:
-        #         compile_instrument(instr, target, directory, generator=MCSTAS_GENERATOR, config=config, dump_source=True)
-        #     except RuntimeError as e:
-        #         log.error(f'Failed to compile instrument: {e}')
-        #         raise e
-        #     binary = Path(directory).joinpath(f'{instr.name}.out')
-        #     self.assertTrue(binary.exists())
-        #     self.assertTrue(binary.is_file())
-        #     self.assertTrue(access(binary, R_OK))
-        #     a1 = asin(pi / d_spacing / mean_ki) * 180 / pi
-        #     parameters = f'a1={a1} a2={2*a1}'
-        #     run_compiled_instrument(binary, target, f"--dir {directory}/instr {parameters}")
-        #
-        #     instr_files = list(Path(directory).joinpath('instr').glob('*.sim'))
-        #     print(instr_files)
-
     def test_assembled_parameters(self):
         """Check that setting an instance parameter to a value that is an instrument parameter name works"""
         assembler = make_mcstas_assembler('assembled_parameters_test_instr')

--- a/test/test_instr.py
+++ b/test/test_instr.py
@@ -412,6 +412,32 @@ class CompiledTest(TestCase):
 
 
 class CompiledInstr(CompiledTest):
+    def _compile_and_run(self, instr, parameters, run=True):
+        from mccode_antlr.compiler.c import compile_instrument, CBinaryTarget, run_compiled_instrument
+        from mccode_antlr.translators.target import MCSTAS_GENERATOR
+        from tempfile import TemporaryDirectory
+        from os import R_OK, access
+        from pathlib import Path
+
+        target = CBinaryTarget(mpi=False, acc=False, count=1, nexus=False)
+        config = dict(default_main=True, enable_trace=False, portable=False, include_runtime=True,
+                      embed_instrument_file=False, verbose=False)
+
+        with TemporaryDirectory() as directory:
+            try:
+                compile_instrument(instr, target, directory, generator=MCSTAS_GENERATOR, config=config, dump_source=True)
+            except RuntimeError as e:
+                log.error(f'Failed to compile instrument: {e}')
+                raise e
+            binary = Path(directory).joinpath(f'{instr.name}.out')
+            self.assertTrue(binary.exists())
+            self.assertTrue(binary.is_file())
+            self.assertTrue(access(binary, R_OK))
+            if run:
+                run_compiled_instrument(binary, target, f"--dir {directory}/instr {parameters}")
+                sim_files = list(Path(directory).glob('**/*.sim'))
+                print(sim_files)
+
     def test_one_axis(self):
         from mccode_antlr.compiler.c import compile_instrument, run_compiled_instrument, CBinaryTarget
         from mccode_antlr.translators.target import MCSTAS_GENERATOR
@@ -450,25 +476,41 @@ class CompiledInstr(CompiledTest):
         """
         instr = parse_mcstas_instr(instr)
 
-        target = CBinaryTarget(mpi=False, acc=False, count=1, nexus=False)
-        config = dict(default_main=True, enable_trace=False, portable=False, include_runtime=True,
-                      embed_instrument_file=False, verbose=False)
-        with TemporaryDirectory() as directory:
-            try:
-                compile_instrument(instr, target, directory, generator=MCSTAS_GENERATOR, config=config, dump_source=True)
-            except RuntimeError as e:
-                log.error(f'Failed to compile instrument: {e}')
-                raise e
-            binary = Path(directory).joinpath(f'{instr.name}.out')
-            self.assertTrue(binary.exists())
-            self.assertTrue(binary.is_file())
-            self.assertTrue(access(binary, R_OK))
-            a1 = asin(pi / d_spacing / mean_ki) * 180 / pi
-            parameters = f'a1={a1} a2={2*a1}'
-            run_compiled_instrument(binary, target, f"--dir {directory}/instr {parameters}")
+        a1 = asin(pi / d_spacing / mean_ki) * 180 / pi
+        parameters = f'a1={a1} a2={2 * a1}'
+        self._compile_and_run(instr, parameters)
 
-            instr_files = list(Path(directory).joinpath('instr').glob('*.sim'))
-            print(instr_files)
+
+        # target = CBinaryTarget(mpi=False, acc=False, count=1, nexus=False)
+        # config = dict(default_main=True, enable_trace=False, portable=False, include_runtime=True,
+        #               embed_instrument_file=False, verbose=False)
+        # with TemporaryDirectory() as directory:
+        #     try:
+        #         compile_instrument(instr, target, directory, generator=MCSTAS_GENERATOR, config=config, dump_source=True)
+        #     except RuntimeError as e:
+        #         log.error(f'Failed to compile instrument: {e}')
+        #         raise e
+        #     binary = Path(directory).joinpath(f'{instr.name}.out')
+        #     self.assertTrue(binary.exists())
+        #     self.assertTrue(binary.is_file())
+        #     self.assertTrue(access(binary, R_OK))
+        #     a1 = asin(pi / d_spacing / mean_ki) * 180 / pi
+        #     parameters = f'a1={a1} a2={2*a1}'
+        #     run_compiled_instrument(binary, target, f"--dir {directory}/instr {parameters}")
+        #
+        #     instr_files = list(Path(directory).joinpath('instr').glob('*.sim'))
+        #     print(instr_files)
+
+    def test_assembled_parameters(self):
+        """Check that setting an instance parameter to a value that is an instrument parameter name works"""
+        assembler = make_mcstas_assembler('assembled_parameters_test_instr')
+        assembler.parameter("double par0 = 3.14159")
+        origin = assembler.component("origin", "Progress_bar", at=[0, 0, 0])
+        left = assembler.component('left', 'Slit', at=([0, 0, 1], origin), rotate=[0, 90, 0],
+                                   parameters=dict(xwidth='par0', yheight='2*fmod(par0, 0.1)'))
+
+        self._compile_and_run(assembler.instrument, None, run=False)
+
 
 
 class CompiledMCPL(CompiledTest):


### PR DESCRIPTION
Instrument parameter names can be used for setting component parameter values, including as part of valid `C` expressions. This is achieved by replacing a component instance parameter value from it's 'bare' identifier, e.g., `x`, to the value contained in the global instrument variable, `instrument_var.parameters.x`, which requires keeping track that the bare identifier _represents_ an instrument parameter.

This book keeping is handled by setting a flag on the `Value` holding the identifier.
When parsing a complete instrument file, the flag can be (and is) set correctly since there is a requirement that all instrument parameters are defined at the top of the file.
When 'assembling' an instrument the same is not necessarily true, and fixing this oversight requires one of two changes:

1. Force a user to specify the instrument parameter(s) used by a component instance _before_ setting the instance parameter value(s) to the instrument parameter name(s). Then change the `Instance` object to hold a reference to its `Instr` so that the instrument-parameter-resolution can take place at value-insertion.
2. Add a check before translation that the parameter flag has been set correctly by recursing through all instance parameter `Expr` trees. This loosens the requirement that the instrument parameters need only be defined prior to the start of translation.

The changes contained here implement the second option.
This may have a negative impact on translation time if the number of component instances, instance parameters, or the depth of parameter setting expression trees is large.
