### PR TITLE
[Fix] vector initializer bug #20

### DIFF
--- a/mccode_antlr/translators/c_decls.py
+++ b/mccode_antlr/translators/c_decls.py
@@ -72,7 +72,7 @@ def declarations_pre_libraries(source, typedefs: list, component_declared_parame
             return z if len(z) and z[0] == '"' and z[-1] == '"' else f'"{z}"'
 
         def one_line(name, typename, value, unit):
-            return f'  {{"{name}", &(_instrument_var._parameters.{name}), {typename}, {nps(value)}, {nps(unit)},}}'
+            return f'  {{"{name}", &(_instrument_var._parameters.{name}), {typename}, {nps(value)}, {nps(unit)}}},'
 
         lines = [f'int numipar = {len(source.parameters)};', 'struct mcinputtable_struct mcinputtable[] = {']
         lines.extend([one_line(p.name, p.value.mccode_c_type_name, p.value, p.unit) for p in source.parameters])

--- a/mccode_antlr/translators/c_decls.py
+++ b/mccode_antlr/translators/c_decls.py
@@ -63,7 +63,7 @@ def declarations_pre_libraries(source, typedefs: list, component_declared_parame
         return '\n'.join(lines)
 
     def instrument_parameters_table():
-        def np_str(x):
+        def nps(x):
             """`None`-protected (single) double-quoted string"""
             z = '' if x is None else f'{x}'
             if z == '"':
@@ -72,23 +72,23 @@ def declarations_pre_libraries(source, typedefs: list, component_declared_parame
             return z if len(z) and z[0] == '"' and z[-1] == '"' else f'"{z}"'
 
         def one_line(name, typename, value, unit):
-            return f'  "{name}", &(_instrument_var._parameters.{name}), {typename}, {np_str(value)}, {np_str(unit)},'
+            return f'  {{"{name}", &(_instrument_var._parameters.{name}), {typename}, {nps(value)}, {nps(unit)},}}'
 
         lines = [f'int numipar = {len(source.parameters)};', 'struct mcinputtable_struct mcinputtable[] = {']
         lines.extend([one_line(p.name, p.value.mccode_c_type_name, p.value, p.unit) for p in source.parameters])
-        lines.extend(['  NULL, NULL, instr_type_double, "", ""'])
+        lines.extend(['  {NULL, NULL, instr_type_double, "", ""}'])
         lines.append("};")
         return '\n'.join(lines)
 
     def metadata_table():
         def one_line(defined_by, name, mimetype, value):
             from ..common.utilities import escape_str_for_c
-            return f'  "{defined_by}", "{name}", "{mimetype}", "{escape_str_for_c(value)}", '
+            return f' {{"{defined_by}", "{name}", "{mimetype}", "{escape_str_for_c(value)}"}}, '
 
         metadata = source.collect_metadata()
         lines = ['struct metadata_table_struct metadata_table[] = {']
         lines.extend([one_line(m.source.name, m.name, m.mimetype, m.value) for m in metadata])
-        lines.extend(['  "", "", "", ""', '};', f'int num_metadata = {len(metadata)};'])
+        lines.extend(['  {"", "", "", ""}', '};', f'int num_metadata = {len(metadata)};'])
         return '\n'.join(lines)
 
     def component_share_declarations():
@@ -160,12 +160,14 @@ def component_type_declaration(comp, typedefs: list, declared_parameters: list):
     ]
     # TODO Veryify that the cogen.c iteration over `comp->def->set_par` does not somehow include DEFINITION PARAMETERS
     for par in comp.setting:
-        # if par.value.is_a(Value.Type.float_array) or par.value.is_a(Value.Type.int_array):
-        if par.value.vector_known:
-            # this is only possible if the value is a tuple of numbers, so no str representations of calculations
-            c_type = par.value.mccode_c_type.translate(str.maketrans('', '', ' *'))  # strip the trailing ' *'
-            lines.append(f'  {c_type} {par.name}[{par.value.vector_len}];')
-        elif par.value.is_str:
+        # FIXME We CANT define a static array here without knowing the maximum size used in every component!
+        # # if par.value.is_a(Value.Type.float_array) or par.value.is_a(Value.Type.int_array):
+        # if par.value.vector_known:
+        #     # this is only possible if the value is a tuple of numbers, so no str representations of calculations
+        #     c_type = par.value.mccode_c_type.translate(str.maketrans('', '', ' *'))  # strip the trailing ' *'
+        #     lines.append(f'  {c_type} {par.name}[{par.value.vector_len}];')
+        # el
+        if par.value.is_str:
             # TODO FIXME The cogen implementation *ALSO* makes static arrays for `vector` parameters?
 
             # the mccode_antlr runtime does not want to allocate or deallocate the memory for this string.

--- a/mccode_antlr/translators/c_finally.py
+++ b/mccode_antlr/translators/c_finally.py
@@ -37,6 +37,12 @@ def cogen_finally(source, declared_parameters):
         if len(comp.type.final):
             lines.append(f'  class_{comp.type.name}_finally(&_{comp.name}_var);')
 
+        for p in comp.parameters:
+            if p.value.is_vector and p.value.vector_known:
+                fullname = f'_{comp.name}_var._parameters.{p.name}'
+                lines.append(f'  if({fullname}) free({fullname});')
+
+
     lines.extend([
         '  siminfo_close();'
         '',
@@ -69,3 +75,24 @@ def cogen_comp_finally_class(comp, declared_parameters):
         ''
     ])
     return lines
+
+
+# def cogen_instance_finally(instance):
+#     lines = [
+#         f'/* component {instance.name} = {instance.type.name}() FINALLY */',
+#         f'void _{instance.name}_finally(void) {{',
+#     ]
+#     if len(instance.type.final):
+#         lines.append(f'  class_{instance.type.name}_finally(&_{instance.name}_var);')
+#
+#     for p in instance.parameters:
+#         if p.value.is_vector and p.value.vector_known:
+#             fullname = f'_{instance.name}_var._parameters.{p.name}'
+#             lines.append(f'  if({fullname}) free({fullname});')
+#
+#     lines.extend([
+#         '} /* _{instance.name}_finally */',
+#         ''
+#     ])
+#
+#     return lines

--- a/mccode_antlr/translators/c_initialise.py
+++ b/mccode_antlr/translators/c_initialise.py
@@ -129,6 +129,9 @@ def cogen_comp_setpos(index, comp, last, instr, component_declared_parameters):
                 pl.append(f"  {fullname}[0] = '\\0';")
         elif default.value.is_vector or p.value.is_vector:
             if p.value.vector_known:
+                # hack-in an allocator for the fixed-length allocated array
+                c_type = par.value.mccode_c_type.translate(str.maketrans('', '', ' *'))  # strip the trailing ' *'
+                pl.append(f'  {fullname} = calloc(sizeof({c_type}), {len(p.value.value)});')
                 for i, v in enumerate(p.value.value):
                     pl.append(f'  {fullname}[{i}] = {v};')
             else:


### PR DESCRIPTION
`vector` valued component parameters are (again) represented by pointers in their component-type parameter struct.

If initialised by an initialiser list in the instance definition, an equal-size memory allocation is made in the _instance_ initialization function, and the individual entries are then set -- one per line.
If the instance definition uses a pointer to initialise the value, no memory is allocated in the `_setpos` function.

The memory allocated by the instance initialiser is freed during the `FINALLY` step, so no  memory is leaked as a result of this change.