### PR TITLE
[Add] mccode-antlr version to generated C file header

### DIFF
--- a/mccode_antlr/translators/c_header.py
+++ b/mccode_antlr/translators/c_header.py
@@ -1,5 +1,6 @@
 def header_pre_runtime(is_mcstas, source, runtime: dict, config: dict, typedefs: list, uservars: list):
     from datetime import datetime
+    from mccode_antlr import version
 
     def jump_line(instance, jump):
         return f'long Jump_{instance.name}_{jump}; /* the JUMP connection <from>_<to> */'
@@ -56,6 +57,7 @@ def header_pre_runtime(is_mcstas, source, runtime: dict, config: dict, typedefs:
     contents = f"""/* Automatically generated file. Do not edit.
  * Format:     ANSI C source code
  * Creator:    {runtime.get("fancy")} <{runtime.get("url")}>
+ * Generator:  mccode-antlr {version()} <https://github.com/McStasMcXtrace/mccode-antlr.git>
  * Instrument: {source.source} ({source.name})
  * Date: {datetime.now()}
  * File: {config.get('output')}


### PR DESCRIPTION
Resolves #26 by adding the `mccode-antlr` module version as a comment to the header of generated C files.