### PR TITLE
[Fix] Issue #51

### DIFF
--- a/mccode_antlr/reader/registry.py
+++ b/mccode_antlr/reader/registry.py
@@ -40,6 +40,7 @@ class Registry:
     name = None
     root = None
     pooch = None
+    version = None
 
     def __str__(self):
         from mccode_antlr.common import TextWrapper
@@ -256,6 +257,7 @@ class LocalRegistry(Registry):
     def __init__(self, name: str, root: str):
         self.name = name
         self.root = Path(root)
+        self.version = mccode_antlr_version()
 
     def to_file(self, output, wrapper):
         contents = '(' + ', '.join([
@@ -398,6 +400,7 @@ def _m_reg(name):
 #     'https://github.com/g5t/mccode-files/raw/main/runtime/libc',
 #     'libc-registry.txt'
 # )
+
 
 MCSTAS_REGISTRY, MCXTRACE_REGISTRY, LIBC_REGISTRY = [_m_reg(name) for name in ('mcstas', 'mcxtrace', 'libc')]
 del _m_reg

--- a/mccode_antlr/translators/target.py
+++ b/mccode_antlr/translators/target.py
@@ -85,10 +85,11 @@ class TargetVisitor:
                 contents = file.read()
 
         # It's not great to do this here. TODO Find a better place for this
-        # FIXME we're (possibly) mixing up McStas/McXtrace and Lib-C versions
-        for reg in self.registries:
-            # updates mccode_antlr.config.config
-            registry_defaults(reg, [reg.name])
+        reg = [reg for reg in self.registries if reg.unique(filename)]
+        if len(reg) != 1:
+            raise RuntimeError(f"Expected exactly one registry for file {filename}")
+        # updates mccode_antlr.config.config
+        registry_defaults(reg[0], [reg[0].name])
 
         def replacement(match) -> str:
             name = match.group(1).lower()


### PR DESCRIPTION
- Add a `version` property to the `Registry` and `LocalRegistry` classes to avoid accessing an undefined object property.
- Update the `TargetVisitor`'s `configure_file` method to pull-out information for _the correct_ registry -- that is the one that provided the to-be-configured file.