### PR TITLE
Use latest mccode-pooch tag instead of 'main'

### DIFF
--- a/mccode_antlr/config/config_default.yaml
+++ b/mccode_antlr/config/config_default.yaml
@@ -14,3 +14,7 @@ mcxtrace:
   libenv: MCXTRACE
   prefix: mx
   project: 2
+mccode_pooch:
+  source: https://github.com/McStasMcXtrace/McCode
+  registry: https://github.com/g5t/mccode-pooch
+  tag: latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     'pooch>=1.7.0',
     'confuse>=2.0.1',
     'loguru>=0.7.2',
+    'gitpython>=3.1.43',
     "importlib_metadata; python_version<'3.8'",
 ]
 description = "ANTLR4 grammars for McStas and McXtrace"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,4 @@
+def test_mccode_pooch_tags():
+    from mccode_antlr.reader.registry import MCSTAS_REGISTRY, MCXTRACE_REGISTRY, LIBC_REGISTRY
+    for reg in (MCSTAS_REGISTRY, MCXTRACE_REGISTRY, LIBC_REGISTRY):
+        assert reg.version != "main"


### PR DESCRIPTION
Fixes #57 by adding a configuration variable for 'mccode-pooch' tag version

By default, the variable is 'latest' to select the most-recent tag (determined when loading the mccode_antlr module).
A user _should_ be able to override this by setting a different value in the module's config file (location platform dependent).
An error is thrown if no tag matches the specified value.

Only the default 'latest' has been tested thus far.