### PR TITLE
[Ref] expose run in Python for Instr objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ hdf5 = ["h5py>=3.11.0"]
 [project.scripts]
 mcstas-antlr = "mccode_antlr.commands:mcstas"
 mcxtrace-antlr = "mccode_antlr.commands:mcxtrace"
-mcrun-antlr = "mccode_antlr.run.runner:mcstas"
-mxrun-antlr = "mccode_antlr.run.runner:mcxtrace"
+mcrun-antlr = "mccode_antlr.run.runner:mcstas_cmd"
+mxrun-antlr = "mccode_antlr.run.runner:mcxtrace_cmd"
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
Move the command line entrypoint function names and re-use  `mccode_run`, `mcstas_run` and `mcxtrace_run` for in-Python scripting.

This will allow for, e.g., `mcstas_run(instr_obj, runtime_directory)` if only the 'default' McStas Registry and Generator are needed.