### PR TITLE
Add a priority number to each registry and sort to start each search with the highest priority

### DIFF
--- a/src/mccode_antlr/assembler/assembler.py
+++ b/src/mccode_antlr/assembler/assembler.py
@@ -9,6 +9,9 @@ class Assembler:
     """Interactive instrument assembly"""
 
     def __init__(self, name: str, registries: list[Registry] = None):
+        from ..reader.registry import ordered_registries
+        if registries is not None:
+            registries = list(ordered_registries(registries))
         self.instrument = Instr(name, source='interactive')
         self.reader = Reader(registries=registries) if registries is not None else Reader()
         self.instrument.registries = self.reader.registries

--- a/src/mccode_antlr/reader/reader.py
+++ b/src/mccode_antlr/reader/reader.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from loguru import logger
 from dataclasses import dataclass, field
 from antlr4.error.ErrorListener import ErrorListener
+from sympy import ordered
+
 from .registry import Registry, MCSTAS_REGISTRY, registries_match, registry_from_specification
 from ..comp import Comp
 from ..common import Mode
@@ -43,8 +45,10 @@ class Reader:
     c_flags: list[str] = field(default_factory=list)
 
     def __post_init__(self):
+        from .registry import ordered_registries
         if len(self.registries) == 0:
             self.registries = [MCSTAS_REGISTRY, ]
+        self.registries = list(ordered_registries(self.registries))
 
     def prepend_registry(self, reg: Registry):
         self.registries[:0] = [reg, ]

--- a/src/mccode_antlr/reader/reader.py
+++ b/src/mccode_antlr/reader/reader.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 from pathlib import Path
 from loguru import logger
 from dataclasses import dataclass, field
-from antlr4.error.ErrorListener import ErrorListener
-from sympy import ordered
 
 from .registry import Registry, MCSTAS_REGISTRY, registries_match, registry_from_specification
 from ..comp import Comp

--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -41,6 +41,7 @@ class Registry:
     root = None
     pooch = None
     version = None
+    priority: int = -1
 
     def __str__(self):
         from mccode_antlr.common import TextWrapper
@@ -112,12 +113,13 @@ def find_registry_file(name: str):
 
 
 class RemoteRegistry(Registry):
-    def __init__(self, name: str, url: str | None, version: str | None, filename: str | None):
+    def __init__(self, name: str, url: str | None, version: str | None, filename: str | None, priority: int = -1):
         self.name = name
         self.url = url
         self.version = version
         self.filename = filename
         self.pooch = None
+        self.priority = priority
 
     @classmethod
     def file_keys(cls) -> tuple[str, ...]:
@@ -196,8 +198,8 @@ class RemoteRegistry(Registry):
 
 
 class ModuleRemoteRegistry(RemoteRegistry):
-    def __init__(self, name: str, url: str, filename=None, version=None):
-        super().__init__(name, url, version, filename)
+    def __init__(self, name: str, url: str, filename=None, version=None, priority: int=-1):
+        super().__init__(name, url, version, filename, priority)
         self.pooch = pooch.create(
             path=pooch.os_cache(f'mccode_antlr-{self.name}'),
             base_url=self.url,
@@ -216,10 +218,10 @@ class ModuleRemoteRegistry(RemoteRegistry):
 
 class GitHubRegistry(RemoteRegistry):
     def __init__(self, name: str, url: str, version: str, filename: str | None = None,
-                 registry: str | dict | None = None):
+                 registry: str | dict | None = None, priority: int = -1):
         if filename is None:
             filename = f'{name}-registry.txt'
-        super().__init__(name, url, version, filename)
+        super().__init__(name, url, version, filename, priority)
         import requests
         base_url = f'{self.url}/raw/{self.version}/'
         # If registry is a string url, we expect the registry file to be available from _that_ url
@@ -258,10 +260,11 @@ class GitHubRegistry(RemoteRegistry):
 
 
 class LocalRegistry(Registry):
-    def __init__(self, name: str, root: str):
+    def __init__(self, name: str, root: str, priority: int = -1):
         self.name = name
         self.root = Path(root)
         self.version = mccode_antlr_version()
+        self.priority = priority
 
     def to_file(self, output, wrapper):
         contents = '(' + ', '.join([
@@ -330,11 +333,12 @@ class LocalRegistry(Registry):
 
 
 class InMemoryRegistry(Registry):
-    def __init__(self, name, **components):
+    def __init__(self, name, priority: int = -1, **components):
         self.name = name
         self.root = '/proc/memory/'  # Something pathlike is needed?
         self.version = mccode_antlr_version()
         self.components = {k: v for k, v in components.items()}
+        self.priority = priority
 
     def add(self, name: str, definition: str):
         self.components[name] = definition
@@ -367,6 +371,11 @@ class InMemoryRegistry(Registry):
         if full_name is not None and full_name in self.components:
             return self.components[full_name]
         raise KeyError(f'InMemoryRegistry does not know of {name if ext is None else name + ext}')
+
+
+def ordered_registries(registries: list[Registry]):
+    """Sort the registries by their priority"""
+    return sorted(registries, key=lambda x: x.priority, reverse=True)
 
 
 def registries_match(registry: Registry, spec):

--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -41,7 +41,7 @@ class Registry:
     root = None
     pooch = None
     version = None
-    priority: int = -1
+    priority: int = 0
 
     def __str__(self):
         from mccode_antlr.common import TextWrapper
@@ -113,7 +113,7 @@ def find_registry_file(name: str):
 
 
 class RemoteRegistry(Registry):
-    def __init__(self, name: str, url: str | None, version: str | None, filename: str | None, priority: int = -1):
+    def __init__(self, name: str, url: str | None, version: str | None, filename: str | None, priority: int = 0):
         self.name = name
         self.url = url
         self.version = version
@@ -198,7 +198,7 @@ class RemoteRegistry(Registry):
 
 
 class ModuleRemoteRegistry(RemoteRegistry):
-    def __init__(self, name: str, url: str, filename=None, version=None, priority: int=-1):
+    def __init__(self, name: str, url: str, filename=None, version=None, priority: int = 0):
         super().__init__(name, url, version, filename, priority)
         self.pooch = pooch.create(
             path=pooch.os_cache(f'mccode_antlr-{self.name}'),
@@ -218,7 +218,7 @@ class ModuleRemoteRegistry(RemoteRegistry):
 
 class GitHubRegistry(RemoteRegistry):
     def __init__(self, name: str, url: str, version: str, filename: str | None = None,
-                 registry: str | dict | None = None, priority: int = -1):
+                 registry: str | dict | None = None, priority: int = 0):
         if filename is None:
             filename = f'{name}-registry.txt'
         super().__init__(name, url, version, filename, priority)
@@ -260,7 +260,7 @@ class GitHubRegistry(RemoteRegistry):
 
 
 class LocalRegistry(Registry):
-    def __init__(self, name: str, root: str, priority: int = -1):
+    def __init__(self, name: str, root: str, priority: int = 10):
         self.name = name
         self.root = Path(root)
         self.version = mccode_antlr_version()
@@ -333,7 +333,7 @@ class LocalRegistry(Registry):
 
 
 class InMemoryRegistry(Registry):
-    def __init__(self, name, priority: int = -1, **components):
+    def __init__(self, name, priority: int = 100, **components):
         self.name = name
         self.root = '/proc/memory/'  # Something pathlike is needed?
         self.version = mccode_antlr_version()
@@ -463,7 +463,7 @@ def _mccode_pooch_registries():
 
     src, reg, tag = source_registry_tag()
 
-    mc, mx, lib = [GitHubRegistry(name, src, tag, registry=reg) for name in ('mcstas', 'mcxtrace', 'libc')]
+    mc, mx, lib = [GitHubRegistry(name, src, tag, registry=reg, priority=-10) for name in ('mcstas', 'mcxtrace', 'libc')]
     return mc, mx, lib
 
 MCSTAS_REGISTRY, MCXTRACE_REGISTRY, LIBC_REGISTRY = _mccode_pooch_registries()

--- a/src/mccode_antlr/translators/c.py
+++ b/src/mccode_antlr/translators/c.py
@@ -257,8 +257,10 @@ class CTargetVisitor(TargetVisitor, target_language='c'):
         languages. (A different target language would not include the same libraries in its raw blocks)
         """
         # Make sure the registry list contains the C library registry, so that we can find and include files
+        from ..reader.registry import ordered_registries
         if not any(reg == LIBC_REGISTRY for reg in self.registries):
             self.source.registries += (LIBC_REGISTRY, )
+        self.source.registries = tuple(ordered_registries(list(self.source.registries)))
 
         includes = []
         inst = self.source

--- a/src/mccode_antlr/translators/target.py
+++ b/src/mccode_antlr/translators/target.py
@@ -50,6 +50,7 @@ class TargetVisitor:
 
     @property
     def registries(self):
+        # TODO always ensure this is sorted by priority?
         return self.source.registries
 
     def known(self, name: str, which: str = None):


### PR DESCRIPTION
By default, McCode repository registries are priority `-10`, 
'normal' registries are `0`, 
'local' (folder based) registries are `10`,
and in-memory registries are `100`.

This should ensure that user-provided files are used before any 'official' remote files.
If this works, then it fixes #73 