### PR TITLE
[Add] support for @LIBRARYFLAGS@ replacements

### DIFF
--- a/src/mccode_antlr/config/platforms.yaml
+++ b/src/mccode_antlr/config/platforms.yaml
@@ -8,6 +8,8 @@ Linux:
     acc: -lm -fast -Minfo=accel -acc=gpu -gpu=managed -DOPENACC -x c -D_POSIX_C_SOURCE
     nexus: -DUSE_NEXUS -lNeXus
     mpi: -DUSE_MPI -lmpi
+    gsl: -lgsl -lgslcblas
+    xrl: -lxrl
   mpi:
     cc: mpicc
     run: mpirun
@@ -22,6 +24,8 @@ Darwin:
     acc: -lm -ta:multicore -DOPENACC -x c -D_DARWIN_C_SOURCE
     nexus: -DUSE_NEXUS -lNeXus
     mpi:  -DUSE_MPI -lmpi
+    gsl: -lgsl -lgslcblas
+    xrl: -lxrl
   mpi:
     cc: mpicc.clang
     run: mpirun
@@ -36,6 +40,8 @@ Windows:
     acc: -lm -ta:multicore -DOPENACC -x c -D_POSIX_C_SOURCE
     nexus: -Wl,-rpath,"C:/Program Files/NeXus Data Format/bin" -L"C:/Program Files/NeXus Data Format/bin" -DUSE_NEXUS -lNeXus-0 -I"C:/Program Files/Nexus Data Format/include/nexus"
     mpi: -DUSE_MPI -lmsmpi
+    gsl: -lgsl -lgslcblas
+    xrl: -lxrl
   mpi:
     cc: mpicc.bat
     run: mpiexec.exe

--- a/src/mccode_antlr/instr/instr.py
+++ b/src/mccode_antlr/instr/instr.py
@@ -290,7 +290,6 @@ class Instr:
         # Each 'flag' in self.flags is from a single instrument component DEPENDENCY, and might contain duplicates:
         # If we accept that white space differences matter, we can deduplicate the strings 'easily'
         unique_flags = set(self.flags)
-        logger.debug(f'{unique_flags = }')
         # The dependency strings are allowed to contain any of
         #       '@NEXUSFLAGS@', @MCCODE_LIB@, CMD(...), ENV(...), GETPATH(...)
         # each of which should be replaced by ... something. Start by replacing the 'static' (old-style) keywords


### PR DESCRIPTION
- Adds support for the GNU Scientific Library flags and 'XRL' flags configured by McStas and/or McXtrace.
- Adds support for _any_ such flag specified as `@{LIBRARY}FLAGS@` which is replaced by `-llibrary` if not found in the system config file.