### PR TITLE
[Fix] LocalRegistry known/fullname glob inconsistency

### DIFF
--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -289,7 +289,7 @@ class LocalRegistry(Registry):
     def unique(self, name: str):
         return len(list(self._file_iterator(name))) == 1
 
-    def fullname(self, name: str, ext: str = None, exact: bool = True):
+    def fullname(self, name: str, ext: str = None, exact: bool = False):
         compare = _name_plus_suffix(name, ext)
         # Complete match
         is_compare = list(self._exact_file_iterator(compare))
@@ -300,6 +300,7 @@ class LocalRegistry(Registry):
         if len(is_name) == 1:
             return is_name[0]
         if not exact:
+            from loguru import logger
             ends_with_compare = list(self._file_iterator(compare))
             if len(ends_with_compare) == 1:
                 return ends_with_compare[0]
@@ -309,6 +310,8 @@ class LocalRegistry(Registry):
                 return ends_with_name[0]
         # Or matching *any* file that contains name
         matches = list(self._file_iterator(name))
+        if len(matches) == 0:
+            raise RuntimeError(f'No match for {compare} or {name} under {self.root}')
         if len(matches) != 1:
             raise RuntimeError(f'More than one match for {name}:{ext}, which is required of:\n{matches}')
         return matches[0]
@@ -316,7 +319,7 @@ class LocalRegistry(Registry):
     def is_available(self, name: str, ext: str = None):
         return self.known(name, ext)
 
-    def path(self, name: str, ext: str = None, exact: bool = True) -> Path:
+    def path(self, name: str, ext: str = None, exact: bool = False) -> Path:
         return self.root.joinpath(self.fullname(name, ext, exact))
 
     def filenames(self) -> list[str]:


### PR DESCRIPTION
The `Reader` asks each `Registry` in turn if it 'knows' a filename. If it does, that `Registry` is then used to retrieve the file 'fullname', 'path', or contents. In the case of `LocalRegistry` the component is searched for in a more-restrictive way for the three latter cases, allowing for the possibility that a `LocalRegistry` 'knows' it has a file but can't find it.

This makes the later checks less stringent, fixing #79, which _could_ have the effect of allowing multiple matches for a file, especially if two copies of the same file (with modifications, presumably) exist in the same directory tree.

For now, this possible drawback is not blocking, since if there is a directory structure like
```
/
├ backup
│   └ ComponentA
│       └ ComponentA.instr
└ ComponentA
    └ ComponentA.instr
```
outside of the runtime directory, then one could specify `-I /ComponentA` or `-I  /backup/ComponentA` (instead of `-I /`) to get just one copy of the same-named file in the `LocalRegistry`.
And a similar layout under the runtime directory would require moving or renaming of files.
