### PR TITLE
Component instance string-valued parameter setting error

### DIFF
--- a/src/mccode_antlr/translators/c_initialise.py
+++ b/src/mccode_antlr/translators/c_initialise.py
@@ -113,8 +113,10 @@ def cogen_comp_setpos(index, comp, last, instr, component_declared_parameters):
         fullname = f'_{comp.name}_var._parameters.{p.name}'
         value = f'{p.value:p}'
         if default.value.is_str or p.value.is_str:
-            # # p might be an identifier, or a string literal, in either case we need to copy it instead of assigning
-            if p.value.is_id:
+            # p might be an identifier, or a string literal, or an operation
+            # (function call, struct member access, ...)
+            # in any case we need to copy it instead of assigning
+            if p.value.is_id or p.value.is_op:
                 pl.extend([
                     f'  if ({value} && strlen({value})){{',
                     f'    stracpy({fullname}, {value}, 16384);',


### PR DESCRIPTION
This pull request includes changes to both the `src/mccode_antlr/translators/c_initialise.py` file and the `tests/runtime/test_examples.py` file. The changes improve the handling of parameter assignments in the initialization code and add a new test for struct instance parameters.

Improvements to parameter handling:

* [`src/mccode_antlr/translators/c_initialise.py`](diffhunk://#diff-811164eb2dae1d151d29d0aa5adcab9f2137ab2590018b9c9ad05a91f99ce5a1L116-R119): Enhanced the `parameter_line` function to handle operations (e.g., function calls, struct member access). This change ensures that identifiers, string literals, and operations are correctly managed.

New test addition:

* [`tests/runtime/test_examples.py`](diffhunk://#diff-b96c745c98ec0b3f59eb2e6d3742d6eb58d044d02b604b1a1d6b0fa0a69fa0acR178-R234): Added a new test function, `test_struct_instance_parameter`, which defines and initializes a struct instance with parameters, and verifies the correct behavior of the instrument simulation. This test ensures that struct parameters are properly handled during initialization and execution.