### PR TITLE
Issue 87 static arrays of arrays

### DIFF
--- a/tests/test_c_type_declaration.py
+++ b/tests/test_c_type_declaration.py
@@ -84,7 +84,7 @@ def test_assignments():
     expected = [
         CDeclarator(dtype='int', declare='blah', init='1'),
         CDeclarator(dtype='double', declare='yarg'),
-        CDeclarator(dtype='char', declare='mmmm', init='"0123456789"', elements=11),
+        CDeclarator(dtype='char', declare='mmmm', init='"0123456789"', elements=(11,)),
     ]
     for x in expected:
         assert x in variables
@@ -121,7 +121,7 @@ def test_typedef_declaration():
     expected = [
         CDeclarator(dtype='blah', declare='really_a_double', init='1.0f'),
         CDeclarator(dtype='blah', declare='double_ptr', pointer='*', init='NULL'),
-        CDeclarator(dtype='blah', declare='double_array', elements=10)
+        CDeclarator(dtype='blah', declare='double_array', elements=(10,))
     ]
     assert all(x in variables for x in expected)
 
@@ -178,14 +178,14 @@ def test_function_pointer_declaration():
         CDeclarator(
             dtype='int',
             declare=CFuncPointer(
-                declare=CDeclarator(pointer='*', declare='fun_ptr_ar3', elements=3),
+                declare=CDeclarator(pointer='*', declare='fun_ptr_ar3', elements=(3,)),
                 args='int, int',
             ),
         ),
         CDeclarator(
             dtype='int',
             declare=CFuncPointer(
-                declare=CDeclarator(pointer='*', declare='fun_ptr_arr', elements=0),
+                declare=CDeclarator(pointer='*', declare='fun_ptr_arr', elements=(0,)),
                 args='int, int',
             ),
             init='{add, sub, mul}',
@@ -198,5 +198,23 @@ def test_function_pointer_declaration():
         'int (* fun_ptr_ar3[3])(int, int)',
         'int (* fun_ptr_arr[3])(int, int)',
     ]
+    for x, y in zip(members, variables):
+        assert x == y.as_struct_member()
+
+def test_multi_level_static_array_types():
+    block = dedent("""\
+    double mmsa[2][3] = {{0, 1, 2}, {3, 4, 5}};
+    int mmi[][][] = {{{0}, {1}}, {{2}, {3}}, {{4}, {5}}, {{6}, {7}}};
+    """)
+    variables, types = extract(block)
+    expected = [
+        CDeclarator(dtype='double', declare='mmsa', elements=(2, 3),
+                    init='{{0, 1, 2}, {3, 4, 5}}',),
+        CDeclarator(dtype='int', declare='mmi', elements=(0, 0, 0),
+                    init='{{{0}, {1}}, {{2}, {3}}, {{4}, {5}}, {{6}, {7}}}')
+    ]
+    for x, y in zip(expected, variables):
+        assert x == y
+    members = ['double mmsa[2][3]', 'int mmi[4][2][1]']
     for x, y in zip(members, variables):
         assert x == y.as_struct_member()

--- a/tests/test_c_type_declaration.py
+++ b/tests/test_c_type_declaration.py
@@ -202,19 +202,31 @@ def test_function_pointer_declaration():
         assert x == y.as_struct_member()
 
 def test_multi_level_static_array_types():
-    block = dedent("""\
-    double mmsa[2][3] = {{0, 1, 2}, {3, 4, 5}};
-    int mmi[][][] = {{{0}, {1}}, {{2}, {3}}, {{4}, {5}}, {{6}, {7}}};
+    big_table=dedent("""{
+    { 2.087063,  0.23391E+00 ,7.485,  2.094,  0.55,	11.81,  63.54,  315,  12.00,  0.30000E+00},
+    { 1.80745 , 0.17544E+00  ,7.485,  2.094,  0.55,	11.81,  63.54,  315,  12.00,  0.30000E+00},
+    { 1.27806 , 0.87718E-01  ,7.485,  2.094,  0.55,	11.81,  63.54,  315,  12.00,  0.30000E+00},
+    { 1.089933,  0.63795E-01 ,7.485,  2.094,  0.55,	11.81,  63.54,  315,  12.00,  0.30000E+00},
+    { 0.903725,  0.43859E-01 ,7.485,  2.094,  0.55,	11.81,  63.54,  315,  12.00,  0.30000E+00},
+    { 0.829315,  0.36934E-01 ,7.485,  2.094,  0.55,	11.81,  63.54,  315,  12.00,  0.30000E+00},
+    { 0.808316,  0.35087E-01 ,7.485,  2.094,  0.55,	11.81,  63.54,  315,  12.00,  0.30000E+00}
+	}""") # .replace('\n','')
+    block = dedent(f"""\
+    double mmsa[2][3] = {{{{0, 1, 2}}, {{3, 4, 5}}}};
+    int mmi[][][] = {{{{{{0}}, {{1}}}}, {{{{2}}, {{3}}}}, {{{{4}}, {{5}}}}, {{{{6}}, {{7}}}}}};
+    double big_table[7][10] = {big_table};
     """)
     variables, types = extract(block)
     expected = [
         CDeclarator(dtype='double', declare='mmsa', elements=(2, 3),
                     init='{{0, 1, 2}, {3, 4, 5}}',),
         CDeclarator(dtype='int', declare='mmi', elements=(0, 0, 0),
-                    init='{{{0}, {1}}, {{2}, {3}}, {{4}, {5}}, {{6}, {7}}}')
+                    init='{{{0}, {1}}, {{2}, {3}}, {{4}, {5}}, {{6}, {7}}}'),
+        CDeclarator(dtype='double', declare='big_table', elements=(7, 10),
+                    init=big_table)
     ]
     for x, y in zip(expected, variables):
         assert x == y
-    members = ['double mmsa[2][3]', 'int mmi[4][2][1]']
+    members = ['double mmsa[2][3]', 'int mmi[4][2][1]', 'double big_table[7][10]']
     for x, y in zip(members, variables):
         assert x == y.as_struct_member()


### PR DESCRIPTION
This pull request focuses on enhancing the handling of multi-dimensional arrays in the `src/mccode_antlr/translators/c_listener.py` file. The changes include updating the `CDeclarator` class to support tuples for array dimensions, introducing a new utility function to extract initializer sizes, and modifying test cases accordingly.

Key changes include:

### Enhancements to Multi-dimensional Array Handling:

* [`src/mccode_antlr/translators/c_listener.py`](diffhunk://#diff-3082e2ca4789ba1d4acbc2a36865b786b1e5bc67c7c42a3b3d488b9378cc17dfL104-R111): Updated the `CDeclarator` class to use tuples for the `elements` attribute, ensuring better support for multi-dimensional arrays. Added a `__post_init__` method to convert `elements` to a tuple if necessary.
* [`src/mccode_antlr/translators/c_listener.py`](diffhunk://#diff-3082e2ca4789ba1d4acbc2a36865b786b1e5bc67c7c42a3b3d488b9378cc17dfL167-R211): Modified the `as_struct_member` method to handle multi-dimensional arrays by adding a `dims` parameter and ensuring `max_array_length` is treated as a tuple.
* [`src/mccode_antlr/translators/c_listener.py`](diffhunk://#diff-3082e2ca4789ba1d4acbc2a36865b786b1e5bc67c7c42a3b3d488b9378cc17dfL167-R211): Added the `extract_initializer_size` function to determine the size of each nested dimension from an initializer string.
* [`src/mccode_antlr/translators/c_listener.py`](diffhunk://#diff-3082e2ca4789ba1d4acbc2a36865b786b1e5bc67c7c42a3b3d488b9378cc17dfL297-R342): Updated the `visitDeclarator` method to parse multi-dimensional array sizes correctly.

### Test Case Updates:

* [`tests/test_c_type_declaration.py`](diffhunk://#diff-2f97e80e650726b0ad3974b501d9282e5215aee99cb026574023503a026632dfL87-R87): Adjusted existing test cases to use tuples for the `elements` attribute. [[1]](diffhunk://#diff-2f97e80e650726b0ad3974b501d9282e5215aee99cb026574023503a026632dfL87-R87) [[2]](diffhunk://#diff-2f97e80e650726b0ad3974b501d9282e5215aee99cb026574023503a026632dfL124-R124) [[3]](diffhunk://#diff-2f97e80e650726b0ad3974b501d9282e5215aee99cb026574023503a026632dfL181-R188)
* [`tests/test_c_type_declaration.py`](diffhunk://#diff-2f97e80e650726b0ad3974b501d9282e5215aee99cb026574023503a026632dfR203-R232): Added a new test case `test_multi_level_static_array_types` to validate the handling of multi-dimensional arrays.