### PR TITLE
Synchronize changes from McCode code generator

### DIFF
--- a/src/mccode_antlr/translators/c.py
+++ b/src/mccode_antlr/translators/c.py
@@ -230,10 +230,18 @@ class CTargetVisitor(TargetVisitor, target_language='c'):
         languages. (A different target language would not include the same libraries in its raw blocks)
         """
         # Make sure the registry list contains the C library registry, so that we can find and include files
+        from packaging.version import Version
         from ..reader.registry import ordered_registries
         if not any(reg == LIBC_REGISTRY for reg in self.registries):
             self.source.registries += (LIBC_REGISTRY, )
         self.source.registries = tuple(ordered_registries(list(self.source.registries)))
+
+        # Check that the LIBC registry is not too old for current translation
+        for reg in self.source.registries:
+            # NeXus interface changed in v3.5.20 release of McStas/McXtrace == McCode
+            if 'libc' == reg.name and Version(reg.version) < Version("3.5.20"):
+                logger.warning(f"Requested McCode libc version {reg.version} may"
+                               " cause errors since it is less than v3.5.20")
 
         includes = []
         inst = self.source

--- a/src/mccode_antlr/translators/c_trace.py
+++ b/src/mccode_antlr/translators/c_trace.py
@@ -55,14 +55,12 @@ def undef_trace_section(is_mcstas: bool):
     lines = [f'#undef {x}' for x in _runtime_parameters(is_mcstas)]
     lines.extend([
         "#ifdef OPENACC",
-        "#ifndef MULTICORE",
         "#undef strlen",
         "#undef strcmp",
         "#undef exit",
         "#undef printf",
         "#undef sprintf",
         "#undef fprintf",
-        "#endif",
         "#endif",
         "#undef SCATTERED",
         "#undef RESTORE",


### PR DESCRIPTION
- Initialization-time output of the code generator to setup NeXus groups for each component was missing, and has now been added.
- There was an pre-processor macro based on `MULTICORE` which McCode removed at some point, and is now removed here too.
- A new libc verison check is an indication of the last-synchronization point for McCode code generator changes.