### PR TITLE
INCOMPLETE Corrections for NOACC component type when targeting GPU / OpenACC

### DIFF
--- a/src/mccode_antlr/config/platforms.yaml
+++ b/src/mccode_antlr/config/platforms.yaml
@@ -5,7 +5,7 @@ Linux:
   flags:
     cc: -g -O2 -std=c99 -x c -D_POSIX_C_SOURCE=2
     ld: -lm
-    acc: -lm -fast -Minfo=accel -acc=gpu -gpu=managed -DOPENACC -x c -D_POSIX_C_SOURCE
+    acc: -lm -fast -Minfo=accel -acc=gpu -gpu=mem:managed -DOPENACC -x c -D_POSIX_C_SOURCE=2
     nexus: -DUSE_NEXUS -lNeXus
     mpi: -DUSE_MPI -lmpi
     gsl: -lgsl -lgslcblas

--- a/src/mccode_antlr/instr/instance.py
+++ b/src/mccode_antlr/instr/instance.py
@@ -39,10 +39,12 @@ class Instance:
 
     def to_file(self, output, wrapper=None, full=True):
         if self.cpu:
-            print(wrapper.line('CPU', []), file=output)
+            line = wrapper.bold('CPU ')
+        else:
+            line = ''
 
         instance_parameters = wrapper.hide(', '.join(p.to_string(wrapper=wrapper) for p in self.parameters))
-        line = wrapper.bold('COMPONENT') + f' {self.name} = {self.type.name}({instance_parameters}) '
+        line = line + wrapper.bold('COMPONENT') + f' {self.name} = {self.type.name}({instance_parameters}) '
 
         if self.when is not None:
             line += wrapper.bold('WHEN') + ' ' + wrapper.escape(str(self.when)) + ' '

--- a/src/mccode_antlr/instr/instance.py
+++ b/src/mccode_antlr/instr/instance.py
@@ -39,12 +39,10 @@ class Instance:
 
     def to_file(self, output, wrapper=None, full=True):
         if self.cpu:
-            line = wrapper.bold('CPU ')
-        else:
-            line = ''
+            print(wrapper.line('CPU', []), file=output, end='')
 
         instance_parameters = wrapper.hide(', '.join(p.to_string(wrapper=wrapper) for p in self.parameters))
-        line = line + wrapper.bold('COMPONENT') + f' {self.name} = {self.type.name}({instance_parameters}) '
+        line = wrapper.bold('COMPONENT') + f' {self.name} = {self.type.name}({instance_parameters}) '
 
         if self.when is not None:
             line += wrapper.bold('WHEN') + ' ' + wrapper.escape(str(self.when)) + ' '
@@ -57,7 +55,7 @@ class Instance:
         # The "AT ..." statement is required even when it is "AT (0, 0, 0) ABSOLUTE"
         line += rf('AT', self.at_relative, required=True) + ' '
         line += rf('ROTATED', self.rotate_relative) + wrapper.br()
-        print(line, file=output)
+        print(line, file=output, end='')
 
         if not full:
             return  # Skip the rest of the output
@@ -110,6 +108,9 @@ class Instance:
             rt = rr[0] if isinstance(rr[0], Angles) else Angles(*rr[0])
             rn, rr = (rr[1].name, rr[1].orientation) if rr[1] else (an, ar)
             self.orientation = Orient.from_dependent_orientations(ar, at, rr, rt)
+        # check if the defining component is marked noacc, in which case this _is_ cpu only
+        if not self.type.acc:
+            self.cpu = True
 
     def set_parameter(self, name: str, value, overwrite=False, allow_repeated=True):
         if not parameter_name_present(self.type.define, name) and not parameter_name_present(self.type.setting, name):

--- a/src/mccode_antlr/instr/instr.py
+++ b/src/mccode_antlr/instr/instr.py
@@ -290,6 +290,9 @@ class Instr:
         # Each 'flag' in self.flags is from a single instrument component DEPENDENCY, and might contain duplicates:
         # If we accept that white space differences matter, we can deduplicate the strings 'easily'
         unique_flags = set(self.flags)
+        if any(inst.cpu for inst in self.components):
+            unique_flags.add('-DFUNNEL')
+
         # The dependency strings are allowed to contain any of
         #       '@NEXUSFLAGS@', @MCCODE_LIB@, CMD(...), ENV(...), GETPATH(...)
         # each of which should be replaced by ... something. Start by replacing the 'static' (old-style) keywords

--- a/src/mccode_antlr/instr/instr.py
+++ b/src/mccode_antlr/instr/instr.py
@@ -286,17 +286,21 @@ class Instr:
                 logger.warning(f'Unknown keyword @{replace}@ in dependency string')
         return flag
 
-    def decoded_flags(self) -> list[str]:
-        # Each 'flag' in self.flags is from a single instrument component DEPENDENCY, and might contain duplicates:
-        # If we accept that white space differences matter, we can deduplicate the strings 'easily'
-        unique_flags = set(self.flags)
+    @property
+    def unique_flags(self) -> set[str]:
+        # Each 'flag' in self.flags is from a single instrument component DEPENDENCY,
+        # and might contain duplicates: If we accept that white space differences
+        # matter, we can deduplicate the strings 'easily'
+        uf = set(self.flags)
         if any(inst.cpu for inst in self.components):
-            unique_flags.add('-DFUNNEL')
+            uf.add('-DFUNNEL')
+        return uf
 
+    def decoded_flags(self) -> list[str]:
         # The dependency strings are allowed to contain any of
         #       '@NEXUSFLAGS@', @MCCODE_LIB@, CMD(...), ENV(...), GETPATH(...)
         # each of which should be replaced by ... something. Start by replacing the 'static' (old-style) keywords
-        replaced_flags = [self._replace_keywords(flag) for flag in unique_flags]
+        replaced_flags = [self._replace_keywords(flag) for flag in self.unique_flags]
         # Then use the above decoder method to replace any instances of CMD, ENV, or GETPATH
         return [self._replace_env_getpath_cmd(flag) for flag in replaced_flags]
 

--- a/src/mccode_antlr/translators/c.py
+++ b/src/mccode_antlr/translators/c.py
@@ -424,3 +424,9 @@ class CTargetVisitor(TargetVisitor, target_language='c'):
         self.embed_file('metadata-r.c')
         self.embed_file('mccode_main.c')
         self.out(f'/* end of generated C code for {self.source.name} */')
+
+    def visit_flags(self):
+        """Output compilation flags to STDOUT, so that (e.g.) mcrun can pick them up"""
+        flags = self.source.decoded_flags()
+        if len(flags):
+            print(f'CFLAGS= {" ".join(flags)}')

--- a/src/mccode_antlr/translators/c_header.py
+++ b/src/mccode_antlr/translators/c_header.py
@@ -73,7 +73,7 @@ def header_pre_runtime(
      * Instrument: {source.source} ({source.name})
      * Date: {datetime.now()}
      * File: {config.get('output')}
-     * CFLAGS={' '.join(set(source.flags))}
+     * CFLAGS={' '.join(source.unique_flags)}
      */
 
     #ifndef WIN32

--- a/src/mccode_antlr/translators/c_raytrace.py
+++ b/src/mccode_antlr/translators/c_raytrace.py
@@ -328,8 +328,6 @@ def cogen_funnel(source, ok_to_skip):
     cpu_last = not source.components[0].cpu if len(source.components) else False
     for index, comp in enumerate(source.components):
         if not comp.type.acc:
-            # NOACC implies to exclusively generate code for CPU via FUNNEL mode
-            comp.cpu=True
             print(f'Component {comp.name} is NOACC, CPUONLY={comp.cpu}')
             print('->FUNNEL mode enabled, SPLIT within buffer.')
             lines.append('        #define JUMP_FUNNEL')

--- a/src/mccode_antlr/translators/c_raytrace.py
+++ b/src/mccode_antlr/translators/c_raytrace.py
@@ -328,6 +328,8 @@ def cogen_funnel(source, ok_to_skip):
     cpu_last = not source.components[0].cpu if len(source.components) else False
     for index, comp in enumerate(source.components):
         if not comp.type.acc:
+            # NOACC implies to exclusively generate code for CPU via FUNNEL mode
+            comp.cpu=True
             print(f'Component {comp.name} is NOACC, CPUONLY={comp.cpu}')
             print('->FUNNEL mode enabled, SPLIT within buffer.')
             lines.append('        #define JUMP_FUNNEL')
@@ -357,7 +359,7 @@ def cogen_funnel(source, ok_to_skip):
             else:
                 lines.extend([
                     "    #ifdef MULTICORE",
-                    "    #pragma acc parallel loop device_type(host)"
+                    "    #pragma acc parallel loop device_type(host)",
                     "    #endif"
                 ])
             lines.extend([

--- a/src/mccode_antlr/translators/target.py
+++ b/src/mccode_antlr/translators/target.py
@@ -173,6 +173,8 @@ class TargetVisitor:
         self.visit_display()
         self.info('visit macros')
         self.visit_macros()
+        self.info('visit flags')
+        self.visit_flags()
         if self.verbose and self.warnings:
             print(f"Build of instrument {self.source.name} had {self.warnings} warnings")
         return self.output
@@ -267,6 +269,7 @@ class TargetVisitor:
     def visit_macros(self):
         pass
 
-        
+    def visit_flags(self):
+        pass
         
 

--- a/tests/runtime/test_raytrace.py
+++ b/tests/runtime/test_raytrace.py
@@ -1,0 +1,86 @@
+from textwrap import dedent
+from mccode_antlr.loader import parse_mcstas_instr
+from .compiled import compiled_test, gpu_compiled_test, compile_and_run
+from mccode_antlr.config import config
+from mccode_antlr.reader.registry import InMemoryRegistry
+
+# config['flags']['acc'] = "-lm -fast -Minfo=accel -acc=host -DOPENACC -x c -D_POSIX_C_SOURCE=2"
+
+FAKE_COMPONENTS = dict(
+    with_noacc=dedent("""DEFINE COMPONENT with_noacc
+    SETTING PARAMETERS (int n)
+    NOACC
+    TRACE
+    %{
+      for (int i= 0; i < n; i++) {
+        printf("%d\\n", i);
+      }
+    %}
+    END
+    """),
+    without_noacc=dedent("""DEFINE COMPONENT without_noacc
+    SETTING PARAMETERS (int n)
+    TRACE
+    %{
+      for (int i= 0; i < n; i++) {
+        printf("%d\\n", i);
+      }
+    %}
+    END
+    """),
+)
+
+in_memory = InMemoryRegistry("test_components")
+for comp, repr in FAKE_COMPONENTS.items():
+    in_memory.add_comp(comp, repr)
+
+
+@gpu_compiled_test
+def test_simple_acc():
+    instr = parse_mcstas_instr(dedent("""
+    define instrument test_simple_acc(dummy=0.)
+    trace
+    component origin = without_noacc() at (0, 0, 0) absolute
+    end
+    """), registries=[in_memory])
+    compile_and_run(instr, '-n 1 dummy=2', target={'acc': True})
+
+
+@gpu_compiled_test
+def test_cpu_only_instance():
+    instr = parse_mcstas_instr(dedent("""
+    define instrument test_cpu_only_instance(dummy=0.)
+    trace
+    component origin = without_noacc() at (0, 0, 0) absolute
+    cpu component ordered = without_noacc() at (0, 0, 1) absolute
+    component disordered = without_noacc() at (0, 0, 2) absolute
+    end
+    """), registries=[in_memory])
+    compile_and_run(instr, '-n 1 dummy=2', target={'acc': True})
+
+
+
+@gpu_compiled_test
+def test_noacc_component():
+    instr = parse_mcstas_instr(dedent("""
+    define instrument test_noacc_instance(dummy=0.)
+    trace
+    component origin = without_noacc() at (0, 0, 0) absolute
+    component ordered = with_noacc() at (0, 0, 1) absolute
+    end
+    """), registries=[in_memory])
+    compile_and_run(instr, '-n 1 dummy=2', target={'acc': True})
+
+
+@gpu_compiled_test
+def test_cpu_and_noacc_component():
+    instr = parse_mcstas_instr(dedent("""
+    define instrument test_cpu_and_noacc_component(dummy=0.)
+    trace
+    component origin = without_noacc() at (0, 0, 0) absolute
+    cpu component ordered = with_noacc() at (0, 0, 1) absolute
+    end
+    """), registries=[in_memory])
+    compile_and_run(instr, '-n 1 dummy=2', target={'acc': True})
+
+

--- a/tests/runtime/test_raytrace.py
+++ b/tests/runtime/test_raytrace.py
@@ -22,13 +22,15 @@ FAKE_COMPONENTS = dict(
     SETTING PARAMETERS (int n)
     TRACE
     %{
-      for (int i= 0; i < n; i++) {
-        printf("%d\\n", i);
+      double store = 3.14159;
+      for (int i = 0; i < n; i++) {
+        store /= 2.0;
       }
     %}
     END
     """),
 )
+
 
 in_memory = InMemoryRegistry("test_components")
 for comp, repr in FAKE_COMPONENTS.items():

--- a/tests/runtime/test_raytrace.py
+++ b/tests/runtime/test_raytrace.py
@@ -4,7 +4,37 @@ from .compiled import compiled_test, gpu_compiled_test, compile_and_run
 from mccode_antlr.config import config
 from mccode_antlr.reader.registry import InMemoryRegistry
 
+
 # config['flags']['acc'] = "-lm -fast -Minfo=accel -acc=host -DOPENACC -x c -D_POSIX_C_SOURCE=2"
+
+
+class Capturing(list):
+    def __enter__(self):
+        from io import StringIO
+        import sys
+        self._stdout = sys.stdout
+        sys.stdout = self._stringio = StringIO()
+        return self
+
+    def __exit__(self, *args):
+        import sys
+        self.extend(self._stringio.getvalue().splitlines())
+        del self._stringio  # free up some memory
+        sys.stdout = self._stdout
+
+
+def instrument_translation_prints_funnel(instr):
+    import re
+    from mccode_antlr.compiler.c import instrument_source
+    from mccode_antlr.translators.target import MCSTAS_GENERATOR
+    # Check that the McStas-parsing of the instrument prints '-DFUNNEL' to STDOUT
+    with Capturing() as output:
+        instrument_source(instr, MCSTAS_GENERATOR, {}, False)
+
+    flags_line = re.compile('^CFLAGS=.*$')
+
+    return any('-DFUNNEL' in line for line in output if flags_line.match(line))
+
 
 FAKE_COMPONENTS = dict(
     with_noacc=dedent("""DEFINE COMPONENT with_noacc
@@ -45,6 +75,7 @@ def test_simple_acc():
     component origin = without_noacc() at (0, 0, 0) absolute
     end
     """), registries=[in_memory])
+    assert not instrument_translation_prints_funnel(instr)
     compile_and_run(instr, '-n 1 dummy=2', target={'acc': True})
 
 
@@ -58,6 +89,7 @@ def test_cpu_only_instance():
     component disordered = without_noacc() at (0, 0, 2) absolute
     end
     """), registries=[in_memory])
+    assert instrument_translation_prints_funnel(instr)
     compile_and_run(instr, '-n 1 dummy=2', target={'acc': True})
 
 
@@ -71,6 +103,7 @@ def test_noacc_component():
     component ordered = with_noacc() at (0, 0, 1) absolute
     end
     """), registries=[in_memory])
+    assert instrument_translation_prints_funnel(instr)
     compile_and_run(instr, '-n 1 dummy=2', target={'acc': True})
 
 
@@ -83,6 +116,7 @@ def test_cpu_and_noacc_component():
     cpu component ordered = with_noacc() at (0, 0, 1) absolute
     end
     """), registries=[in_memory])
+    assert instrument_translation_prints_funnel(instr)
     compile_and_run(instr, '-n 1 dummy=2', target={'acc': True})
 
 


### PR DESCRIPTION
https://github.com/McStasMcXtrace/mccode-antlr/issues/109

@g5t I've tested this functional at least for `ISIS_CRISP.instr`, built a patched `mccode-antlr` and generated attached c-code locally on my Mac, transported to my 8-way GPU machine and ran on all the GPUS in parallel there:

![Screenshot 2025-02-06 at 19 38 31](https://github.com/user-attachments/assets/d72d464f-03f5-49b5-ba42-e084d7dff967)

[ISIS_CRISP.c.txt](https://github.com/user-attachments/files/18694708/ISIS_CRISP.c.txt)

For a reason I do not yet fully understand the code generated for NCrystal_example (perhaps 2 instances of the NCrystal_sample?) still fails to compile w/OpenACC.
[NCrystal_example.c.txt](https://github.com/user-attachments/files/18694733/NCrystal_example.c.txt)
