### PR TITLE
Correct `DEPENDENCY` concatenation

### DIFF
--- a/src/mccode_antlr/compiler/c.py
+++ b/src/mccode_antlr/compiler/c.py
@@ -118,12 +118,12 @@ def windows_split_flags(instrument: Instr, target: CBinaryTarget):
         flag = flag.strip()
         if (flag.startswith('/D') or flag.startswith('-D')) and not flag == '/DYNAMICBASE':
             # assume this is a macro definition for cl.exe
-            compiler_flags.extend(flag)
+            compiler_flags.append(flag)
         elif flag.startswith('/p:') and '=' in flag:
             # this is _always_(?) a macro define to have a specific value
-            compiler_flags.extend(flag)
+            compiler_flags.append(flag)
         else:
-            linker_flags.extend(flag)
+            linker_flags.append(flag)
 
     # Check for OpenACC or NeXus in flags?
     return compiler_flags, linker_flags

--- a/src/mccode_antlr/loader/loader.py
+++ b/src/mccode_antlr/loader/loader.py
@@ -22,8 +22,8 @@ def parse_mccode_instr(contents: str, registries: list[Registry], source: str = 
     reader = Reader(registries=registries)
     visitor = InstrVisitor(reader, source or '<string>')
     instr = visitor.visitProg(McInstr_parse(InputStream(contents), 'prog'))
-    instr.flags = tuple(reader.c_flags)
-    instr.registries = tuple(registries)
+    instr.flags += tuple(reader.c_flags)
+    instr.registries += tuple(registries)
     return instr
 
 

--- a/tests/runtime/test_nexus.py
+++ b/tests/runtime/test_nexus.py
@@ -1,21 +1,18 @@
 from textwrap import dedent
 from mccode_antlr.loader import parse_mcstas_instr
 from .compiled import compiled_test, compile_and_run
-from mccode_antlr.config import config
 from mccode_antlr.reader.registry import InMemoryRegistry
 
-
-# config['flags']['acc'] = "-lm -fast -Minfo=accel -acc=host -DOPENACC -x c -D_POSIX_C_SOURCE=2"
 
 FAKE_COMPONENTS = dict(
     check_for_define=dedent(r"""DEFINE COMPONENT check_for_define
     SETTING PARAMETERS (int n)
     TRACE
     %{
-    #ifdef UNUSUAL_MACRO_CONTROL
-    printf("UNUSUAL_MACRO_CONTROL set\n");
+    #ifdef UNUSUAL_MACRO
+    printf("UNUSUAL_MACRO set\n");
     #else
-    printf("UNUSUAL_MACRO_CONTROL not set\n");
+    printf("UNUSUAL_MACRO not set\n");
     #endif
     %}
     END
@@ -30,6 +27,11 @@ FAKE_COMPONENTS = dict(
 )
 
 
+def macro_name():
+    from platform import system
+    return "/DUNUSUAL_MACRO" if system() == "Windows" else "-DUNUSUAL_MACRO"
+
+
 in_memory = InMemoryRegistry("test_components")
 for comp, repr in FAKE_COMPONENTS.items():
     in_memory.add_comp(comp, repr)
@@ -37,18 +39,18 @@ for comp, repr in FAKE_COMPONENTS.items():
 
 @compiled_test
 def test_instr_dependency():
-    instr = parse_mcstas_instr(dedent("""
+    instr = parse_mcstas_instr(dedent(f"""
     define instrument test_instr_dependency(dummy=0.)
-    DEPENDENCY "-DUNUSUAL_MACRO_CONTROL"
+    DEPENDENCY "{macro_name()}"
     trace
     component origin = check_for_define() at (0, 0, 0) absolute
     end
     """), registries=[in_memory])
-    assert any('-DUNUSUAL_MACRO_CONTROL' == x for x in instr.flags)
+    assert any(macro_name() == x for x in instr.flags)
     results, data = compile_and_run(instr, '-n 1 dummy=2')
     lines = results.decode('utf-8').splitlines()
-    assert sum('UNUSUAL_MACRO_CONTROL set' == x for x in lines) == 1
-    assert sum('UNUSUAL_MACRO_CONTROL not set' == x for x in lines) == 0
+    assert sum('UNUSUAL_MACRO set' == x for x in lines) == 1
+    assert sum('UNUSUAL_MACRO not set' == x for x in lines) == 0
 
 
 @compiled_test
@@ -59,11 +61,11 @@ def test_instr_no_dependency():
     component origin = check_for_define() at (0, 0, 0) absolute
     end
     """), registries=[in_memory])
-    assert not any('-DUNUSUAL_MACRO_CONTROL' == x for x in instr.flags)
+    assert not any(macro_name() == x for x in instr.flags)
     results, data = compile_and_run(instr, '-n 1 dummy=2')
     lines = results.decode('utf-8').splitlines()
-    assert sum('UNUSUAL_MACRO_CONTROL set' == x for x in lines) == 0
-    assert sum('UNUSUAL_MACRO_CONTROL not set' == x for x in lines) == 1
+    assert sum('UNUSUAL_MACRO set' == x for x in lines) == 0
+    assert sum('UNUSUAL_MACRO not set' == x for x in lines) == 1
 
 
 def test_nexus_key_is_expanded():

--- a/tests/runtime/test_nexus.py
+++ b/tests/runtime/test_nexus.py
@@ -1,0 +1,81 @@
+from textwrap import dedent
+from mccode_antlr.loader import parse_mcstas_instr
+from .compiled import compiled_test, compile_and_run
+from mccode_antlr.config import config
+from mccode_antlr.reader.registry import InMemoryRegistry
+
+
+# config['flags']['acc'] = "-lm -fast -Minfo=accel -acc=host -DOPENACC -x c -D_POSIX_C_SOURCE=2"
+
+FAKE_COMPONENTS = dict(
+    check_for_define=dedent(r"""DEFINE COMPONENT check_for_define
+    SETTING PARAMETERS (int n)
+    TRACE
+    %{
+    #ifdef UNUSUAL_MACRO_CONTROL
+    printf("UNUSUAL_MACRO_CONTROL set\n");
+    #else
+    printf("UNUSUAL_MACRO_CONTROL not set\n");
+    #endif
+    %}
+    END
+    """),
+    check_for_nexus=dedent(r"""DEFINE COMPONENT check_for_nexus
+    SETTING PARAMETERS (int n)
+    TRACE
+    %{
+    %}
+    END
+    """)
+)
+
+
+in_memory = InMemoryRegistry("test_components")
+for comp, repr in FAKE_COMPONENTS.items():
+    in_memory.add_comp(comp, repr)
+
+
+@compiled_test
+def test_instr_dependency():
+    instr = parse_mcstas_instr(dedent("""
+    define instrument test_instr_dependency(dummy=0.)
+    DEPENDENCY "-DUNUSUAL_MACRO_CONTROL"
+    trace
+    component origin = check_for_define() at (0, 0, 0) absolute
+    end
+    """), registries=[in_memory])
+    assert any('-DUNUSUAL_MACRO_CONTROL' == x for x in instr.flags)
+    results, data = compile_and_run(instr, '-n 1 dummy=2')
+    lines = results.decode('utf-8').splitlines()
+    assert sum('UNUSUAL_MACRO_CONTROL set' == x for x in lines) == 1
+    assert sum('UNUSUAL_MACRO_CONTROL not set' == x for x in lines) == 0
+
+
+@compiled_test
+def test_instr_no_dependency():
+    instr = parse_mcstas_instr(dedent("""
+    define instrument test_instr_no_dependency(dummy=0.)
+    trace
+    component origin = check_for_define() at (0, 0, 0) absolute
+    end
+    """), registries=[in_memory])
+    assert not any('-DUNUSUAL_MACRO_CONTROL' == x for x in instr.flags)
+    results, data = compile_and_run(instr, '-n 1 dummy=2')
+    lines = results.decode('utf-8').splitlines()
+    assert sum('UNUSUAL_MACRO_CONTROL set' == x for x in lines) == 0
+    assert sum('UNUSUAL_MACRO_CONTROL not set' == x for x in lines) == 1
+
+
+def test_nexus_key_is_expanded():
+    from mccode_antlr.config import config
+    instr = parse_mcstas_instr(dedent("""
+       define instrument test_nexus_key_is_expanded(dummy=0.)
+       DEPENDENCY "@NEXUSFLAGS@"
+       trace
+       component origin = check_for_nexus() at (0, 0, 0) absolute
+       end
+       """), registries=[in_memory])
+    assert any('@NEXUSFLAGS@' == x for x in instr.flags)
+    assert not any('@NEXUSFLAGS@' == x for x in instr.decoded_flags())
+    nexus_flags = config['flags']['nexus'].get()
+    assert any(nexus_flags == x for x in instr.decoded_flags())


### PR DESCRIPTION
As found by @willend `instr` level `DEPENDENCY` specifications were indeed being omitted, due to a typo when combining component and instrument flags (`=` in place of `+=`).
 
The `@NEXUSFLAGS@` keyword in `CFLAGS` is being converted to the system-specific set of compiler flags -- I can't verify if these 
are actually correct or not however.

This should fix #112 

---

A test is added for the instrument dependency (including that not-setting the macro should work as expected, unlike `USE_OFF` which is automatically unset/set by the presence of OpenACC macros).

Similarly a test checks that the `@NEXUSFLAGS@` keyword gets expanded; a better test would actually check if that results in anything changing in the runtime.