### PR TITLE
Implement C header specialization for McXtrace vs McStas

### DIFF
--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -357,7 +357,7 @@ class InMemoryRegistry(Registry):
         self.name = name
         self.root = '/proc/memory/'  # Something pathlike is needed?
         self.version = mccode_antlr_version()
-        self.components = {k: v for k, v in components.items()}
+        self.components = {k if k.lower().endswith('.comp') else f'{k}.comp': v for k, v in components.items()}
         self.priority = priority
 
     def add(self, name: str, definition: str):

--- a/src/mccode_antlr/translators/c_particle.py
+++ b/src/mccode_antlr/translators/c_particle.py
@@ -1,0 +1,123 @@
+def xyz_Axyz_Bxyz(is_mcstas, type_str):
+    """Return lists of particle struct members
+
+    Either:
+        (x, y, z), (vx, vy, vz), (sx, sy, sz)
+    or
+        (x, y, z), (kx, ky, kz, phi), (Ex, Ey, Ez)
+    """
+    xyz = ('x', 'y', 'z')
+    ps = ('', 'v', 's') if is_mcstas else ('', 'k', 'E')
+    z, a, b = (tuple((f'{p}{x}', type_str) for x in xyz) for p in ps)
+    if not is_mcstas:
+        a = a + (('phi', type_str),)
+    return z, a, b
+
+
+
+def struct_members(is_mcstas: bool):
+    """Get the name and type of the members of the _class_particle struct
+
+    The members of the struct are not equivalent between McStas and McXtrace
+    """
+    z, a, b = xyz_Axyz_Bxyz(is_mcstas, 'double')
+    if is_mcstas:
+        a = a +  (
+            ('mcgravitation', 'int'),
+            ('mcMagnet', 'void *'),
+            ('allow_backprop', 'int')
+        )
+
+    members = (z + a + b) + (
+        ('_mctmp_a', 'double'),
+        ('_mctmp_b', 'double'),
+        ('_mctmp_c', 'double'),
+        ('randstate', 'unsigned long []'),
+        ('t', 'double'),
+        ('p', 'double'),
+        ('_uid', 'long long'),
+        ('_index', 'long'),
+        ('_absorbed', 'long'),
+        ('_scattered', 'long'),
+        ('_restore', 'long'),
+        ('flag_nocoordschange', 'long'),
+        ('_logic', 'struct particle_logic_struct'),
+        # uservars
+    )
+    return {k: v for k, v in members}
+
+def accessible_struct_members(is_mcstas: bool):
+    """Get the name and type of the accessible members of the _class_particle struct
+
+    The members of the struct are not equivalent between McStas and McXtrace
+
+    Note
+    ----
+    Used in the generated C code by, e.g.,
+        double particle_getvar(...)
+        void particle_getvar_void(...)
+        int particle_setvar_void(...)
+        void particle_restore(...)
+    written-out here within c_header.py
+    """
+    z, a, b = xyz_Axyz_Bxyz(is_mcstas, 'double')
+    members = (z + a + b) + (
+        ('t', 'double'),
+        ('p', 'double'),
+        ('_mctmp_a', 'double'),
+        ('_mctmp_b', 'double'),
+        ('_mctmp_c', 'double'),
+        # uservars
+    )
+    return {k: v for k, v in members}
+
+def restorable_struct_members(is_mcstas: bool):
+    """Get the name and type of the restorable members of the _class_particle struct
+
+    The members of the struct are not equivalent between McStas and McXtrace
+
+    Note
+    ----
+    Used in the generated C code by, e.g.,
+        void particle_restore(...)
+    written-out here within c_header.py
+    """
+    z, a, b = xyz_Axyz_Bxyz(is_mcstas, 'double')
+    members = z + a + b + (('t', 'double'), ('p', 'double'),)
+    return {k: v for k, v in members}
+
+
+def setstate_signature_members(is_mcstas: bool):
+    z, a, b = xyz_Axyz_Bxyz(is_mcstas, 'double')
+    members = (
+        z + a + (('t', 'double'),) + b
+        + (
+            ('p', 'double'),
+            ('mcgravitation', 'int'),
+            ('mcMagnet', 'void *'),
+            ('allow_backprop', 'int')
+        )
+    )
+    return {k: v for k, v in members}
+
+
+def getstate_signature_members(is_mcstas):
+    z, a, b = xyz_Axyz_Bxyz(is_mcstas, 'double *')
+    members = (
+            (('mcparticle', '_class_particle'),)
+            + z + a + (('t', 'double *'),) + b + (('p', 'double *'),)
+    )
+    return {k: v for k, v in members}
+
+
+
+def setstate_signature_call(is_mcstas: bool):
+    values = {
+        'vz' if is_mcstas else 'kz': '1',
+        'p': '1',
+        'mcgravitation': 'mcgravitation',
+        'mcMagnet': 'NULL',
+        'allow_backprop': 'mcallowbackprop',
+    }
+    members = setstate_signature_members(is_mcstas)
+    return [values.get(key, '0') for key in members]

--- a/tests/runtime/compiled.py
+++ b/tests/runtime/compiled.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from functools import cache
+from enum import Enum
 import pytest
 
 from mccode_antlr.compiler.check import simple_instr_compiles
@@ -45,13 +46,26 @@ def mcpl_compiled_test(method):
     return method
 
 
-def compile_and_run(instr, parameters, run=True, dump_source=True, target: dict | None = None, config: dict | None = None):
+class Flavor(Enum):
+    MCSTAS=1
+    MCXTRACE=2
+
+
+def compile_and_run(instr,
+                    parameters,
+                    run=True,
+                    dump_source=True,
+                    target: dict | None = None,
+                    config: dict | None = None,
+                    flavor: Flavor = Flavor.MCSTAS):
     from pathlib import Path
     from tempfile import TemporaryDirectory
-    from mccode_antlr.translators.target import MCSTAS_GENERATOR
+    from mccode_antlr.translators.target import MCSTAS_GENERATOR, MCXTRACE_GENERATOR
     from mccode_antlr.run import mccode_compile, mccode_run_compiled
 
-    kwargs = dict(generator=MCSTAS_GENERATOR, target=target, config=config, dump_source=dump_source)
+    generator = MCXTRACE_GENERATOR if flavor == Flavor.MCXTRACE else MCSTAS_GENERATOR
+
+    kwargs = dict(generator=generator, target=target, config=config, dump_source=dump_source)
 
     with TemporaryDirectory() as directory:
         binary, target = mccode_compile(instr, directory, **kwargs)

--- a/tests/runtime/test_mcxtrace.py
+++ b/tests/runtime/test_mcxtrace.py
@@ -1,0 +1,45 @@
+from textwrap import dedent
+from mccode_antlr.loader import parse_mcstas_instr
+from .compiled import compiled_test, compile_and_run, Flavor
+from mccode_antlr.reader.registry import InMemoryRegistry
+
+in_memory = InMemoryRegistry(
+    "test_components",
+    trace_counter=dedent("""DEFINE COMPONENT trace_counter
+    SETTING PARAMETERS (int n)
+    NOACC
+    TRACE
+    %{
+      for (int i= 0; i < n; i++) {
+        printf("%d\\n", i);
+      }
+    %}
+    END
+    """),
+    useless=dedent("""DEFINE COMPONENT useless
+    SETTING PARAMETERS (int n)
+    TRACE 
+    %{
+    %}
+    END
+    """),
+)
+
+
+@compiled_test
+def test_simplest_mcstas():
+    instr = parse_mcstas_instr(dedent("""
+    define instrument test_simplest_mcstas(dummy=0.)
+    trace component origin = useless() at (0, 0, 0) absolute end
+    """), registries=[in_memory])
+    compile_and_run(instr, '-n 1 dummy=2', flavor=Flavor.MCSTAS)
+
+
+@compiled_test
+def test_simplest_mcxtrace():
+    instr = parse_mcstas_instr(dedent("""
+    define instrument test_simplest_mcxtrace(dummy=0.)
+    trace component origin = useless() at (0, 0, 0) absolute end
+    """), registries=[in_memory])
+    compile_and_run(instr, '-n 1 dummy=2', flavor=Flavor.MCXTRACE)
+


### PR DESCRIPTION
As indicated by @willend in #113 the translation performed by, e.g., `mcxtrace-antlr`, does not produce a file which can compile.

This is due to different `_class_particle` struct definitions between `McStas` and `McXtrace` and simply overlooking this difference previously.

The different struct members are correctly handled by this PR, and a _very_ simple McXtrace test is added to ensure that a generated file can compile.

This fixes #113 barring other unrelated problems.